### PR TITLE
Add enterprise component primitives

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,6 @@ on:
 jobs:
   verify:
     runs-on: ubuntu-latest
-    env:
-      CHROMATIC_PROJECT_TOKEN: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
 
     steps:
       - name: Checkout
@@ -41,14 +39,6 @@ jobs:
 
       - name: Run UI tests
         run: npm run test:ui
-
-      - name: Run visual regression tests
-        if: ${{ env.CHROMATIC_PROJECT_TOKEN != '' }}
-        run: npm run test:visual:ci
-
-      - name: Skip visual regression tests
-        if: ${{ env.CHROMATIC_PROJECT_TOKEN == '' }}
-        run: echo "CHROMATIC_PROJECT_TOKEN is not configured; skipping Chromatic visual regression tests."
 
       - name: Upload Playwright report
         if: failure()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   verify:
     runs-on: ubuntu-latest
+    env:
+      CHROMATIC_PROJECT_TOKEN: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
 
     steps:
       - name: Checkout
@@ -39,6 +41,14 @@ jobs:
 
       - name: Run UI tests
         run: npm run test:ui
+
+      - name: Upload Storybook to Chromatic
+        if: ${{ env.CHROMATIC_PROJECT_TOKEN != '' }}
+        run: npm run test:visual:ci
+
+      - name: Skip Chromatic upload
+        if: ${{ env.CHROMATIC_PROJECT_TOKEN == '' }}
+        run: echo "CHROMATIC_PROJECT_TOKEN is not configured; skipping Chromatic upload."
 
       - name: Upload Playwright report
         if: failure()

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "test:ui": "playwright test",
     "test:ui:build": "npm run build:storybook && playwright test",
     "test:visual": "npm run build:storybook && chromatic --storybook-build-dir storybook-static --only-changed",
-    "test:visual:ci": "chromatic --storybook-build-dir storybook-static --only-changed --ci",
+    "test:visual:ci": "chromatic --storybook-build-dir storybook-static --only-changed --ci --exit-once-uploaded",
     "publish:pack": "yarn build && npm pack --pack-destination ./packed"
   },
   "peerDependencies": {

--- a/src/components/PBadge/PBadge.css
+++ b/src/components/PBadge/PBadge.css
@@ -1,0 +1,131 @@
+.p-badge {
+  --p-badge-bg: var(--p-color-surface-subtle);
+  --p-badge-bg-solid: var(--p-color-surface-inverse);
+  --p-badge-border: var(--p-color-border);
+  --p-badge-text: var(--p-color-text);
+  --p-badge-text-solid: var(--p-color-text-inverse);
+  --p-badge-radius: var(--p-radius-xs);
+  --p-badge-font-size: var(--p-font-size-caption);
+  --p-badge-font-weight: var(--p-font-weight-medium);
+  --p-badge-line-height: var(--p-line-height-caption);
+  --p-badge-min-height: 1.5rem;
+  --p-badge-padding-x: var(--p-space-2);
+  --p-badge-gap: var(--p-space-1);
+  --p-badge-icon-size: var(--p-size-icon-sm);
+
+  display: inline-flex;
+  max-width: 100%;
+  min-width: 0;
+  min-height: var(--p-badge-min-height);
+  align-items: center;
+  justify-content: center;
+  gap: var(--p-badge-gap);
+  border: 1px solid transparent;
+  border-radius: var(--p-badge-radius);
+  font-family: var(--p-font-family-sans);
+  font-size: var(--p-badge-font-size);
+  font-weight: var(--p-badge-font-weight);
+  letter-spacing: var(--p-letter-spacing-default);
+  line-height: var(--p-badge-line-height);
+  padding-inline: var(--p-badge-padding-x);
+  text-align: center;
+  text-decoration: none;
+  vertical-align: middle;
+  white-space: nowrap;
+}
+
+.p-badge--sm {
+  --p-badge-min-height: 1.5rem;
+  --p-badge-padding-x: var(--p-space-2);
+  --p-badge-font-size: var(--p-font-size-caption);
+  --p-badge-line-height: var(--p-line-height-caption);
+  --p-badge-icon-size: var(--p-size-icon-sm);
+}
+
+.p-badge--md {
+  --p-badge-min-height: 1.75rem;
+  --p-badge-padding-x: var(--p-space-3);
+  --p-badge-font-size: var(--p-font-size-body-sm);
+  --p-badge-line-height: var(--p-line-height-body-sm);
+}
+
+.p-badge--subtle {
+  border-color: var(--p-badge-border);
+  background: var(--p-badge-bg);
+  color: var(--p-badge-text);
+}
+
+.p-badge--solid {
+  border-color: var(--p-badge-bg-solid);
+  background: var(--p-badge-bg-solid);
+  color: var(--p-badge-text-solid);
+}
+
+.p-badge--outline {
+  border-color: var(--p-badge-border);
+  background: transparent;
+  color: var(--p-badge-text);
+}
+
+.p-badge--primary {
+  --p-badge-bg: var(--p-color-action-primary-subtle);
+  --p-badge-bg-solid: var(--p-color-action-primary);
+  --p-badge-border: var(--p-color-action-primary);
+  --p-badge-text: var(--p-color-action-primary);
+}
+
+.p-badge--danger {
+  --p-badge-bg: var(--p-color-danger-surface);
+  --p-badge-bg-solid: var(--p-color-danger);
+  --p-badge-border: var(--p-color-danger-border);
+  --p-badge-text: var(--p-color-danger-hover);
+}
+
+.p-badge--warning {
+  --p-badge-bg: var(--p-color-warning-surface);
+  --p-badge-bg-solid: var(--p-color-warning);
+  --p-badge-border: var(--p-color-warning-border);
+  --p-badge-text: var(--p-color-text);
+  --p-badge-text-solid: var(--p-color-neutral-950);
+}
+
+.p-badge--success {
+  --p-badge-bg: var(--p-color-success-surface);
+  --p-badge-bg-solid: var(--p-color-success);
+  --p-badge-border: var(--p-color-success-border);
+  --p-badge-text: var(--p-color-success);
+}
+
+.p-badge--info {
+  --p-badge-bg: var(--p-color-info-surface);
+  --p-badge-bg-solid: var(--p-color-info);
+  --p-badge-border: var(--p-color-info-border);
+  --p-badge-text: var(--p-color-info);
+}
+
+.p-badge--neutral {
+  --p-badge-bg: var(--p-color-surface-subtle);
+  --p-badge-bg-solid: var(--p-color-surface-inverse);
+  --p-badge-border: var(--p-color-border);
+  --p-badge-text: var(--p-color-text-muted);
+}
+
+.p-badge__label {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.p-badge__icon {
+  display: inline-flex;
+  width: var(--p-badge-icon-size);
+  height: var(--p-badge-icon-size);
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: center;
+}
+
+.p-badge__icon > svg {
+  width: 100%;
+  height: 100%;
+}

--- a/src/components/PBadge/PBadge.stories.tsx
+++ b/src/components/PBadge/PBadge.stories.tsx
@@ -1,0 +1,125 @@
+import { type Meta, type StoryObj } from '@storybook/react';
+import { PBadge } from '.';
+
+function DotIcon() {
+  return (
+    <svg viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+      <circle cx="8" cy="8" r="4" />
+    </svg>
+  );
+}
+
+const meta: Meta<typeof PBadge> = {
+  title: 'Components/PBadge',
+  component: PBadge,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered',
+  },
+  args: {
+    children: 'Active',
+    variant: 'neutral',
+    size: 'sm',
+    appearance: 'subtle',
+  },
+  argTypes: {
+    as: {
+      description: 'Rendered element. Defaults to span for inline status text.',
+    },
+    variant: {
+      control: 'select',
+      options: ['primary', 'danger', 'warning', 'success', 'info', 'neutral'],
+      description: 'Semantic status color.',
+    },
+    size: {
+      control: 'select',
+      options: ['sm', 'md'],
+      description: 'Badge density.',
+    },
+    appearance: {
+      control: 'select',
+      options: ['subtle', 'solid', 'outline'],
+      description: 'Visual treatment for the badge.',
+    },
+    leftIcon: {
+      description: 'Decorative icon rendered before the label.',
+    },
+    rightIcon: {
+      description: 'Decorative icon rendered after the label.',
+    },
+  },
+};
+
+type Story = StoryObj<typeof PBadge>;
+
+export const Default: Story = {
+  name: 'Default',
+};
+
+export const Variants: Story = {
+  name: 'Variants',
+  render: () => (
+    <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.75rem' }}>
+      <PBadge variant="primary">Primary</PBadge>
+      <PBadge variant="success">Approved</PBadge>
+      <PBadge variant="warning">Pending</PBadge>
+      <PBadge variant="danger">Blocked</PBadge>
+      <PBadge variant="info">Info</PBadge>
+      <PBadge variant="neutral">Draft</PBadge>
+    </div>
+  ),
+};
+
+export const Appearances: Story = {
+  name: 'Appearances',
+  render: () => (
+    <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.75rem' }}>
+      <PBadge variant="success" appearance="subtle">
+        Subtle
+      </PBadge>
+      <PBadge variant="success" appearance="solid">
+        Solid
+      </PBadge>
+      <PBadge variant="success" appearance="outline">
+        Outline
+      </PBadge>
+    </div>
+  ),
+};
+
+export const Sizes: Story = {
+  name: 'Sizes',
+  render: () => (
+    <div style={{ display: 'flex', alignItems: 'center', gap: '0.75rem' }}>
+      <PBadge size="sm">Small</PBadge>
+      <PBadge size="md">Medium</PBadge>
+    </div>
+  ),
+};
+
+export const WithIcon: Story = {
+  name: 'With Icon',
+  args: {
+    variant: 'success',
+    leftIcon: <DotIcon />,
+    children: 'Online',
+  },
+};
+
+export const Truncated: Story = {
+  name: 'Truncated',
+  decorators: [
+    (Story) => (
+      <div style={{ width: 120 }}>
+        <Story />
+      </div>
+    ),
+  ],
+  args: {
+    variant: 'info',
+    children: 'Long status label',
+    style: { width: '100%' },
+  },
+};
+
+export default meta;

--- a/src/components/PBadge/PBadge.tsx
+++ b/src/components/PBadge/PBadge.tsx
@@ -1,0 +1,67 @@
+import {
+  forwardRef,
+  type ElementType,
+  type HTMLAttributes,
+  type ReactNode,
+} from 'react';
+import cn from '../../utils/cn';
+import './PBadge.css';
+
+export type PBadgeVariant = 'primary' | 'danger' | 'warning' | 'success' | 'info' | 'neutral';
+export type PBadgeSize = 'sm' | 'md';
+export type PBadgeAppearance = 'subtle' | 'solid' | 'outline';
+export type PBadgeRef = HTMLElement;
+
+export type PBadgeProps = {
+  as?: ElementType;
+  variant?: PBadgeVariant;
+  size?: PBadgeSize;
+  appearance?: PBadgeAppearance;
+  leftIcon?: ReactNode;
+  rightIcon?: ReactNode;
+  children: ReactNode;
+  className?: string;
+} & Omit<HTMLAttributes<HTMLElement>, 'children' | 'className' | 'color'>;
+
+export const PBadge = forwardRef<PBadgeRef, PBadgeProps>(
+  (
+    {
+      as: Element = 'span',
+      variant = 'neutral',
+      size = 'sm',
+      appearance = 'subtle',
+      leftIcon,
+      rightIcon,
+      children,
+      className,
+      ...props
+    },
+    ref,
+  ) => (
+    <Element
+      {...props}
+      ref={ref}
+      className={cn(
+        'p-badge',
+        `p-badge--${variant}`,
+        `p-badge--${size}`,
+        `p-badge--${appearance}`,
+        className,
+      )}
+    >
+      {leftIcon && (
+        <span className="p-badge__icon" aria-hidden="true">
+          {leftIcon}
+        </span>
+      )}
+      <span className="p-badge__label">{children}</span>
+      {rightIcon && (
+        <span className="p-badge__icon" aria-hidden="true">
+          {rightIcon}
+        </span>
+      )}
+    </Element>
+  ),
+);
+
+PBadge.displayName = 'PBadge';

--- a/src/components/PBadge/index.ts
+++ b/src/components/PBadge/index.ts
@@ -1,0 +1,8 @@
+export {
+  PBadge,
+  type PBadgeAppearance,
+  type PBadgeProps,
+  type PBadgeRef,
+  type PBadgeSize,
+  type PBadgeVariant,
+} from './PBadge';

--- a/src/components/PButton/PButton.css
+++ b/src/components/PButton/PButton.css
@@ -23,7 +23,8 @@
   position: relative;
   display: inline-flex;
   width: auto;
-  min-width: max-content;
+  max-width: 100%;
+  min-width: 0;
   min-height: var(--p-button-min-height);
   align-items: center;
   justify-content: center;
@@ -54,6 +55,11 @@
 
 .p-button:active {
   background: var(--p-button-bg-active);
+}
+
+.p-button--active {
+  background: var(--p-button-bg-active);
+  border-color: var(--p-button-border-hover);
 }
 
 .p-button:focus {
@@ -125,7 +131,8 @@
 }
 
 .p-button--tertiary:hover,
-.p-button--tertiary:active {
+.p-button--tertiary:active,
+.p-button--tertiary.p-button--active {
   --p-button-text: var(--p-color-text-inverse);
 }
 
@@ -155,6 +162,12 @@
   flex: 0 0 auto;
 }
 
+.p-button__label {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 .p-button__icon {
   display: inline-flex;
   align-items: center;
@@ -176,6 +189,25 @@
 @media (prefers-reduced-motion: reduce) {
   .p-button__spinner {
     animation-duration: 1.2s;
+  }
+}
+
+@media (max-width: 40rem) {
+  .p-button {
+    --p-button-padding-x: var(--p-space-3);
+    --p-button-gap: var(--p-space-1);
+  }
+
+  .p-button--sm {
+    --p-button-min-height: var(--p-size-touch-min);
+  }
+
+  .p-button--lg {
+    --p-button-min-height: var(--p-size-control-md);
+    --p-button-padding-x: var(--p-space-4);
+    --p-button-font-size: var(--p-font-size-body-sm);
+    --p-button-line-height: var(--p-line-height-body-sm);
+    --p-button-icon-size: var(--p-size-icon-md);
   }
 }
 

--- a/src/components/PButton/PButton.css
+++ b/src/components/PButton/PButton.css
@@ -1,0 +1,186 @@
+.p-button {
+  --p-button-bg: var(--p-color-action-primary);
+  --p-button-bg-hover: var(--p-color-action-primary-hover);
+  --p-button-bg-active: var(--p-color-action-primary-hover);
+  --p-button-border: var(--p-color-action-primary);
+  --p-button-border-hover: var(--p-color-action-primary-hover);
+  --p-button-text: var(--p-color-text-inverse);
+  --p-button-ring: var(--p-focus-ring-color);
+  --p-button-radius: var(--p-radius-sm);
+  --p-button-border-width: 1px;
+  --p-button-font-size: var(--p-font-size-body-sm);
+  --p-button-font-weight: var(--p-font-weight-medium);
+  --p-button-line-height: var(--p-line-height-body-sm);
+  --p-button-min-height: var(--p-size-control-md);
+  --p-button-padding-x: var(--p-space-4);
+  --p-button-gap: var(--p-space-2);
+  --p-button-icon-size: var(--p-size-icon-md);
+  --p-button-transition: background-color var(--p-duration-fast) var(--p-ease-standard),
+    border-color var(--p-duration-fast) var(--p-ease-standard),
+    color var(--p-duration-fast) var(--p-ease-standard),
+    box-shadow var(--p-duration-fast) var(--p-ease-standard);
+
+  position: relative;
+  display: inline-flex;
+  width: auto;
+  min-width: max-content;
+  min-height: var(--p-button-min-height);
+  align-items: center;
+  justify-content: center;
+  gap: var(--p-button-gap);
+  border: var(--p-button-border-width) solid var(--p-button-border);
+  border-radius: var(--p-button-radius);
+  background: var(--p-button-bg);
+  color: var(--p-button-text);
+  font-family: var(--p-font-family-sans);
+  font-size: var(--p-button-font-size);
+  font-weight: var(--p-button-font-weight);
+  line-height: var(--p-button-line-height);
+  padding-inline: var(--p-button-padding-x);
+  text-align: center;
+  text-decoration: none;
+  white-space: nowrap;
+  cursor: pointer;
+  user-select: none;
+  transition: var(--p-button-transition);
+}
+
+.p-button:hover {
+  background: var(--p-button-bg-hover);
+  border-color: var(--p-button-border-hover);
+  color: var(--p-button-text);
+  text-decoration: none;
+}
+
+.p-button:active {
+  background: var(--p-button-bg-active);
+}
+
+.p-button:focus {
+  outline: none;
+}
+
+.p-button:focus-visible {
+  box-shadow: 0 0 0 var(--p-focus-ring-width) var(--p-button-ring);
+  outline: var(--p-focus-outline-width) solid transparent;
+  outline-offset: var(--p-focus-ring-offset);
+}
+
+.p-button:disabled,
+.p-button[aria-disabled='true'] {
+  pointer-events: none;
+  opacity: var(--p-opacity-disabled);
+}
+
+.p-button--full-width {
+  width: 100%;
+  min-width: 0;
+}
+
+.p-button--sm {
+  --p-button-min-height: var(--p-size-control-sm);
+  --p-button-padding-x: var(--p-space-3);
+  --p-button-font-size: var(--p-font-size-caption);
+  --p-button-line-height: var(--p-line-height-caption);
+  --p-button-icon-size: var(--p-size-icon-sm);
+}
+
+.p-button--md {
+  --p-button-min-height: var(--p-size-control-md);
+}
+
+.p-button--lg {
+  --p-button-min-height: var(--p-size-control-lg);
+  --p-button-padding-x: var(--p-space-5);
+  --p-button-font-size: var(--p-font-size-body-md);
+  --p-button-line-height: var(--p-line-height-body-md);
+  --p-button-icon-size: var(--p-size-icon-lg);
+}
+
+.p-button--primary {
+  --p-button-bg: var(--p-color-action-primary);
+  --p-button-bg-hover: var(--p-color-action-primary-hover);
+  --p-button-bg-active: var(--p-color-action-primary-hover);
+  --p-button-border: var(--p-color-action-primary);
+  --p-button-border-hover: var(--p-color-action-primary-hover);
+  --p-button-text: var(--p-color-text-inverse);
+}
+
+.p-button--secondary {
+  --p-button-bg: var(--p-color-surface);
+  --p-button-bg-hover: var(--p-color-surface-subtle);
+  --p-button-bg-active: var(--p-color-surface-subtle);
+  --p-button-border: var(--p-color-border-strong);
+  --p-button-border-hover: var(--p-color-border-strong);
+  --p-button-text: var(--p-color-text);
+}
+
+.p-button--tertiary {
+  --p-button-bg: var(--p-color-action-primary-subtle);
+  --p-button-bg-hover: var(--p-color-action-primary);
+  --p-button-bg-active: var(--p-color-action-primary-hover);
+  --p-button-border: transparent;
+  --p-button-border-hover: var(--p-color-action-primary);
+  --p-button-text: var(--p-color-action-primary);
+}
+
+.p-button--tertiary:hover,
+.p-button--tertiary:active {
+  --p-button-text: var(--p-color-text-inverse);
+}
+
+.p-button--danger {
+  --p-button-bg: var(--p-color-danger);
+  --p-button-bg-hover: var(--p-color-danger-hover);
+  --p-button-bg-active: var(--p-color-danger-hover);
+  --p-button-border: var(--p-color-danger);
+  --p-button-border-hover: var(--p-color-danger-hover);
+  --p-button-text: var(--p-color-text-inverse);
+  --p-button-ring: var(--p-color-danger);
+}
+
+.p-button--ghost {
+  --p-button-bg: transparent;
+  --p-button-bg-hover: var(--p-color-surface-subtle);
+  --p-button-bg-active: var(--p-color-surface-subtle);
+  --p-button-border: transparent;
+  --p-button-border-hover: transparent;
+  --p-button-text: var(--p-color-text);
+}
+
+.p-button__icon,
+.p-button__spinner {
+  width: var(--p-button-icon-size);
+  height: var(--p-button-icon-size);
+  flex: 0 0 auto;
+}
+
+.p-button__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.p-button__icon > svg {
+  width: 100%;
+  height: 100%;
+}
+
+.p-button__spinner {
+  border: 2px solid currentColor;
+  border-right-color: transparent;
+  border-radius: var(--p-radius-full);
+  animation: p-button-spin var(--p-duration-slow) linear infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .p-button__spinner {
+    animation-duration: 1.2s;
+  }
+}
+
+@keyframes p-button-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/src/components/PButton/PButton.stories.tsx
+++ b/src/components/PButton/PButton.stories.tsx
@@ -1,0 +1,187 @@
+import { type Meta, type StoryObj } from '@storybook/react';
+import { PButton } from '.';
+
+function ArrowRightIcon() {
+  return (
+    <svg
+      viewBox="0 0 20 20"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.75"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M4 10h12" />
+      <path d="m11 5 5 5-5 5" />
+    </svg>
+  );
+}
+
+function PlusIcon() {
+  return (
+    <svg
+      viewBox="0 0 20 20"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.75"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M10 4v12" />
+      <path d="M4 10h12" />
+    </svg>
+  );
+}
+
+const meta: Meta<typeof PButton> = {
+  title: 'Components/PButton',
+  component: PButton,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered',
+  },
+  args: {
+    children: 'Button',
+    variant: 'primary',
+    size: 'md',
+  },
+  argTypes: {
+    variant: {
+      control: 'select',
+      options: ['primary', 'secondary', 'tertiary', 'danger', 'ghost'],
+      description: 'Visual treatment mapped to semantic action tokens.',
+    },
+    size: {
+      control: 'select',
+      options: ['sm', 'md', 'lg'],
+      description: 'Control size. Medium and large meet the enterprise touch target by default.',
+    },
+    fullWidth: {
+      description: 'Expands the button to fill its container.',
+    },
+    isLoading: {
+      description: 'Shows a spinner and disables interaction while preserving the label.',
+    },
+    href: {
+      description: 'When provided, renders the component as an anchor with button styling.',
+    },
+    disabled: {
+      description: 'Disables button interaction. Anchors use `aria-disabled` and are removed from tab order.',
+    },
+    leftIcon: {
+      description: 'Decorative icon rendered before the label.',
+    },
+    rightIcon: {
+      description: 'Decorative icon rendered after the label.',
+    },
+  },
+};
+
+type Story = StoryObj<typeof PButton>;
+
+export const Primary: Story = {
+  name: 'Primary',
+};
+
+export const Secondary: Story = {
+  name: 'Secondary',
+  args: {
+    variant: 'secondary',
+  },
+};
+
+export const Tertiary: Story = {
+  name: 'Tertiary',
+  args: {
+    variant: 'tertiary',
+  },
+};
+
+export const Danger: Story = {
+  name: 'Danger',
+  args: {
+    variant: 'danger',
+    children: 'Delete record',
+  },
+};
+
+export const Ghost: Story = {
+  name: 'Ghost',
+  args: {
+    variant: 'ghost',
+  },
+};
+
+export const WithIcons: Story = {
+  name: 'With Icons',
+  args: {
+    leftIcon: <PlusIcon />,
+    rightIcon: <ArrowRightIcon />,
+    children: 'Create item',
+  },
+};
+
+export const Loading: Story = {
+  name: 'Loading',
+  args: {
+    isLoading: true,
+    children: 'Saving',
+  },
+};
+
+export const Disabled: Story = {
+  name: 'Disabled',
+  args: {
+    disabled: true,
+  },
+};
+
+export const Link: Story = {
+  name: 'Link',
+  args: {
+    href: '#',
+    children: 'Open details',
+    rightIcon: <ArrowRightIcon />,
+  },
+};
+
+export const Sizes: Story = {
+  name: 'Sizes',
+  render: () => (
+    <div style={{ display: 'flex', alignItems: 'center', gap: '1rem' }}>
+      <PButton size="sm">Small</PButton>
+      <PButton size="md">Medium</PButton>
+      <PButton size="lg">Large</PButton>
+    </div>
+  ),
+};
+
+export const Variants: Story = {
+  name: 'Variants',
+  render: () => (
+    <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.75rem' }}>
+      <PButton>Primary</PButton>
+      <PButton variant="secondary">Secondary</PButton>
+      <PButton variant="tertiary">Tertiary</PButton>
+      <PButton variant="danger">Danger</PButton>
+      <PButton variant="ghost">Ghost</PButton>
+    </div>
+  ),
+};
+
+export const FullWidth: Story = {
+  name: 'Full Width',
+  decorators: [
+    (Story) => (
+      <div style={{ width: 360 }}>
+        <Story />
+      </div>
+    ),
+  ],
+  args: {
+    fullWidth: true,
+    children: 'Continue',
+  },
+};
+
+export default meta;

--- a/src/components/PButton/PButton.stories.tsx
+++ b/src/components/PButton/PButton.stories.tsx
@@ -59,6 +59,9 @@ const meta: Meta<typeof PButton> = {
     fullWidth: {
       description: 'Expands the button to fill its container.',
     },
+    isActive: {
+      description: 'Applies the persistent active/current visual state.',
+    },
     isLoading: {
       description: 'Shows a spinner and disables interaction while preserving the label.',
     },
@@ -129,6 +132,14 @@ export const Loading: Story = {
   },
 };
 
+export const Active: Story = {
+  name: 'Active',
+  args: {
+    isActive: true,
+    children: 'Current view',
+  },
+};
+
 export const Disabled: Story = {
   name: 'Disabled',
   args: {
@@ -181,6 +192,27 @@ export const FullWidth: Story = {
   args: {
     fullWidth: true,
     children: 'Continue',
+  },
+};
+
+export const Mobile: Story = {
+  name: 'Mobile',
+  parameters: {
+    viewport: {
+      defaultViewport: 'mobile1',
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ width: 320 }}>
+        <Story />
+      </div>
+    ),
+  ],
+  args: {
+    fullWidth: true,
+    rightIcon: <ArrowRightIcon />,
+    children: 'Review and continue',
   },
 };
 

--- a/src/components/PButton/PButton.tsx
+++ b/src/components/PButton/PButton.tsx
@@ -17,6 +17,7 @@ type PButtonBaseProps = {
   variant?: PButtonVariant;
   size?: PButtonSize;
   fullWidth?: boolean;
+  isActive?: boolean;
   isLoading?: boolean;
   leftIcon?: ReactNode;
   rightIcon?: ReactNode;
@@ -46,6 +47,7 @@ export const PButton = forwardRef<PButtonRef, PButtonProps>(
       variant = 'primary',
       size = 'md',
       fullWidth = false,
+      isActive = false,
       isLoading = false,
       leftIcon,
       rightIcon,
@@ -61,6 +63,7 @@ export const PButton = forwardRef<PButtonRef, PButtonProps>(
       `p-button--${variant}`,
       `p-button--${size}`,
       fullWidth && 'p-button--full-width',
+      isActive && 'p-button--active',
       className,
     );
     const content = (
@@ -74,7 +77,7 @@ export const PButton = forwardRef<PButtonRef, PButtonProps>(
             </span>
           )
         )}
-        <span>{children}</span>
+        <span className="p-button__label">{children}</span>
         {!isLoading && rightIcon && (
           <span className="p-button__icon" aria-hidden="true">
             {rightIcon}
@@ -103,6 +106,7 @@ export const PButton = forwardRef<PButtonRef, PButtonProps>(
           className={buttonClassName}
           aria-disabled={isUnavailable || undefined}
           aria-busy={isLoading || undefined}
+          data-active={isActive || undefined}
           data-disabled={anchorDisabled || undefined}
           tabIndex={isUnavailable ? -1 : anchorProps.tabIndex}
           onClick={handleClick}
@@ -123,6 +127,7 @@ export const PButton = forwardRef<PButtonRef, PButtonProps>(
         disabled={Boolean(buttonDisabled || isLoading)}
         className={buttonClassName}
         aria-busy={isLoading || undefined}
+        data-active={isActive || undefined}
       >
         {content}
       </button>

--- a/src/components/PButton/PButton.tsx
+++ b/src/components/PButton/PButton.tsx
@@ -1,0 +1,133 @@
+import {
+  forwardRef,
+  type AnchorHTMLAttributes,
+  type ButtonHTMLAttributes,
+  type MouseEvent,
+  type Ref,
+  type ReactNode,
+} from 'react';
+import cn from '../../utils/cn';
+import './PButton.css';
+
+export type PButtonVariant = 'primary' | 'secondary' | 'tertiary' | 'danger' | 'ghost';
+export type PButtonSize = 'sm' | 'md' | 'lg';
+export type PButtonRef = HTMLButtonElement | HTMLAnchorElement;
+
+type PButtonBaseProps = {
+  variant?: PButtonVariant;
+  size?: PButtonSize;
+  fullWidth?: boolean;
+  isLoading?: boolean;
+  leftIcon?: ReactNode;
+  rightIcon?: ReactNode;
+  children: ReactNode;
+  className?: string;
+};
+
+type PButtonAsButtonProps = PButtonBaseProps &
+  Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'className' | 'children'> & {
+    href?: undefined;
+  };
+
+type PButtonAsAnchorProps = PButtonBaseProps &
+  Omit<AnchorHTMLAttributes<HTMLAnchorElement>, 'className' | 'children'> & {
+    href: string;
+    disabled?: boolean;
+    type?: never;
+  };
+
+export type PButtonProps = PButtonAsButtonProps | PButtonAsAnchorProps;
+type PButtonAnchorElementProps = Omit<PButtonAsAnchorProps, keyof PButtonBaseProps>;
+type PButtonButtonElementProps = Omit<PButtonAsButtonProps, keyof PButtonBaseProps>;
+
+export const PButton = forwardRef<PButtonRef, PButtonProps>(
+  (
+    {
+      variant = 'primary',
+      size = 'md',
+      fullWidth = false,
+      isLoading = false,
+      leftIcon,
+      rightIcon,
+      children,
+      className,
+      ...props
+    },
+    ref,
+  ) => {
+    const isUnavailable = Boolean(('disabled' in props && props.disabled) || isLoading);
+    const buttonClassName = cn(
+      'p-button',
+      `p-button--${variant}`,
+      `p-button--${size}`,
+      fullWidth && 'p-button--full-width',
+      className,
+    );
+    const content = (
+      <>
+        {isLoading ? (
+          <span className="p-button__spinner" aria-hidden="true" />
+        ) : (
+          leftIcon && (
+            <span className="p-button__icon" aria-hidden="true">
+              {leftIcon}
+            </span>
+          )
+        )}
+        <span>{children}</span>
+        {!isLoading && rightIcon && (
+          <span className="p-button__icon" aria-hidden="true">
+            {rightIcon}
+          </span>
+        )}
+      </>
+    );
+
+    if ('href' in props && typeof props.href === 'string') {
+      const { disabled: anchorDisabled, onClick, ...anchorProps } =
+        props as PButtonAnchorElementProps;
+
+      const handleClick = (event: MouseEvent<HTMLAnchorElement>) => {
+        if (isUnavailable) {
+          event.preventDefault();
+          return;
+        }
+
+        onClick?.(event);
+      };
+
+      return (
+        <a
+          {...anchorProps}
+          ref={ref as Ref<HTMLAnchorElement>}
+          className={buttonClassName}
+          aria-disabled={isUnavailable || undefined}
+          aria-busy={isLoading || undefined}
+          data-disabled={anchorDisabled || undefined}
+          tabIndex={isUnavailable ? -1 : anchorProps.tabIndex}
+          onClick={handleClick}
+        >
+          {content}
+        </a>
+      );
+    }
+
+    const { type = 'button', disabled: buttonDisabled, ...buttonProps } =
+      props as PButtonButtonElementProps;
+
+    return (
+      <button
+        {...buttonProps}
+        ref={ref as Ref<HTMLButtonElement>}
+        type={type}
+        disabled={Boolean(buttonDisabled || isLoading)}
+        className={buttonClassName}
+        aria-busy={isLoading || undefined}
+      >
+        {content}
+      </button>
+    );
+  },
+);
+
+PButton.displayName = 'PButton';

--- a/src/components/PButton/index.ts
+++ b/src/components/PButton/index.ts
@@ -1,0 +1,1 @@
+export { PButton, type PButtonProps, type PButtonRef } from './PButton';

--- a/src/components/PCard/PCard.css
+++ b/src/components/PCard/PCard.css
@@ -8,15 +8,21 @@
   --p-card-radius: var(--p-radius-sm);
   --p-card-padding: var(--p-space-4);
   --p-card-gap: var(--p-space-4);
+  --p-card-min-width: 0;
   --p-card-min-height: 11.25rem;
   --p-card-width: 16.25rem;
+  --p-card-height: auto;
   --p-card-transition: background-color var(--p-duration-fast) var(--p-ease-standard),
     border-color var(--p-duration-fast) var(--p-ease-standard),
     box-shadow var(--p-duration-fast) var(--p-ease-standard);
 
   position: relative;
   display: flex;
-  width: min(100%, var(--p-card-width));
+  box-sizing: border-box;
+  width: var(--p-card-width);
+  height: var(--p-card-height);
+  max-width: 100%;
+  min-width: var(--p-card-min-width);
   min-height: var(--p-card-min-height);
   flex-direction: column;
   gap: var(--p-card-gap);
@@ -43,6 +49,15 @@
 
 .p-card--full-width {
   width: 100%;
+}
+
+.p-card--custom-width:not(.p-card--full-width),
+.p-card--custom-min-width:not(.p-card--full-width) {
+  max-width: none;
+}
+
+.p-card--custom-height:not(.p-card--custom-min-height) {
+  min-height: 0;
 }
 
 .p-card--interactive {
@@ -103,10 +118,27 @@
   white-space: nowrap;
 }
 
+.p-card__meta-custom {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--p-space-1);
+  font-family: var(--p-font-family-sans);
+  font-size: var(--p-font-size-body-sm);
+  font-weight: var(--p-font-weight-medium);
+  letter-spacing: var(--p-letter-spacing-wide);
+  line-height: var(--p-line-height-body-sm);
+  text-transform: uppercase;
+}
+
+.p-card__meta-custom svg {
+  width: var(--p-size-icon-sm);
+  height: var(--p-size-icon-sm);
+  color: currentColor;
+}
+
 .p-card__body {
   display: grid;
   gap: var(--p-space-2);
-  margin-block-start: auto;
 }
 
 .p-card__title {

--- a/src/components/PCard/PCard.css
+++ b/src/components/PCard/PCard.css
@@ -1,0 +1,147 @@
+.p-card {
+  --p-card-bg: var(--p-color-surface);
+  --p-card-bg-hover: var(--p-color-surface-subtle);
+  --p-card-border: var(--p-color-border);
+  --p-card-border-hover: var(--p-color-border-strong);
+  --p-card-text: var(--p-color-text);
+  --p-card-text-muted: var(--p-color-text-muted);
+  --p-card-radius: var(--p-radius-sm);
+  --p-card-padding: var(--p-space-4);
+  --p-card-gap: var(--p-space-4);
+  --p-card-min-height: 11.25rem;
+  --p-card-width: 16.25rem;
+  --p-card-transition: background-color var(--p-duration-fast) var(--p-ease-standard),
+    border-color var(--p-duration-fast) var(--p-ease-standard),
+    box-shadow var(--p-duration-fast) var(--p-ease-standard);
+
+  position: relative;
+  display: flex;
+  width: min(100%, var(--p-card-width));
+  min-height: var(--p-card-min-height);
+  flex-direction: column;
+  gap: var(--p-card-gap);
+  border: 1px solid var(--p-card-border);
+  border-radius: var(--p-card-radius);
+  background: var(--p-card-bg);
+  color: var(--p-card-text);
+  padding: var(--p-card-padding);
+  transition: var(--p-card-transition);
+}
+
+.p-card--compact {
+  --p-card-padding: var(--p-space-3);
+  --p-card-gap: var(--p-space-3);
+  --p-card-min-height: 9rem;
+}
+
+.p-card--spacious {
+  --p-card-padding: var(--p-space-6);
+  --p-card-gap: var(--p-space-6);
+  --p-card-min-height: 14rem;
+  --p-card-width: 20rem;
+}
+
+.p-card--full-width {
+  width: 100%;
+}
+
+.p-card--interactive {
+  cursor: pointer;
+}
+
+.p-card--interactive:hover {
+  background: var(--p-card-bg-hover);
+  border-color: var(--p-card-border-hover);
+}
+
+.p-card--interactive:focus-within {
+  outline: none;
+}
+
+.p-card--interactive:focus-within::after {
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  box-shadow: 0 0 0 var(--p-focus-ring-width) var(--p-focus-ring-color);
+  content: '';
+  pointer-events: none;
+}
+
+.p-card__media {
+  min-height: 7.5rem;
+  margin: calc(var(--p-card-padding) * -1);
+  margin-block-end: 0;
+  overflow: hidden;
+  border-start-start-radius: inherit;
+  border-start-end-radius: inherit;
+  background: var(--p-color-surface-subtle);
+}
+
+.p-card__media > img,
+.p-card__media > picture,
+.p-card__media > video {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.p-card__meta {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--p-space-3);
+  color: var(--p-card-text-muted);
+}
+
+.p-card__prefix,
+.p-card__eyebrow {
+  overflow: hidden;
+  color: var(--p-card-text-muted);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.p-card__body {
+  display: grid;
+  gap: var(--p-space-2);
+  margin-block-start: auto;
+}
+
+.p-card__title {
+  margin: 0;
+  color: var(--p-card-text);
+}
+
+.p-card__link {
+  color: inherit;
+  text-decoration: none;
+}
+
+.p-card__link::after {
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  content: '';
+}
+
+.p-card__link:focus {
+  outline: none;
+}
+
+.p-card__description {
+  margin: 0;
+  color: var(--p-card-text-muted);
+}
+
+.p-card__content {
+  color: var(--p-card-text);
+}
+
+.p-card__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--p-space-2);
+  margin-block-start: auto;
+}

--- a/src/components/PCard/PCard.stories.tsx
+++ b/src/components/PCard/PCard.stories.tsx
@@ -1,0 +1,120 @@
+import { type Meta, type StoryObj } from '@storybook/react';
+import { PButton } from '../PButton';
+import { PCard } from '.';
+
+const meta: Meta<typeof PCard> = {
+  title: 'Components/PCard',
+  component: PCard,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered',
+  },
+  args: {
+    prefix: '01',
+    eyebrow: 'Operations',
+    title: 'Pipeline overview',
+    description: 'A compact summary card for scanning enterprise workflows.',
+  },
+  argTypes: {
+    prefix: {
+      description: 'Short leading metadata, often a sequence number.',
+    },
+    eyebrow: {
+      description: 'Short trailing metadata, category, or status text.',
+    },
+    title: {
+      description: 'Main card heading.',
+    },
+    description: {
+      description: 'Optional supporting copy.',
+    },
+    media: {
+      description: 'Optional media/content rendered at the top of the card.',
+    },
+    actions: {
+      description: 'Optional action slot rendered at the bottom.',
+    },
+    density: {
+      control: 'select',
+      options: ['compact', 'default', 'spacious'],
+      description: 'Controls the card padding and minimum height.',
+    },
+    fullWidth: {
+      description: 'Expands the card to fill its container.',
+    },
+    href: {
+      description: 'When provided, the title becomes a link and the whole card gets an interactive state.',
+    },
+  },
+};
+
+type Story = StoryObj<typeof PCard>;
+
+export const Default: Story = {
+  name: 'Default',
+};
+
+export const WithActions: Story = {
+  name: 'With Actions',
+  args: {
+    title: 'Contract queue',
+    description: 'Review pending approvals and route exceptions before the next close cycle.',
+    actions: (
+      <>
+        <PButton size="sm">Review</PButton>
+        <PButton size="sm" variant="secondary">
+          Export
+        </PButton>
+      </>
+    ),
+  },
+};
+
+export const WithoutDescription: Story = {
+  name: 'Without Description',
+  args: {
+    prefix: '02',
+    eyebrow: 'Queue',
+    title: 'Title-only card',
+    description: undefined,
+  },
+};
+
+export const WithMedia: Story = {
+  name: 'With Media',
+  args: {
+    title: 'Account health',
+    description: 'A visual block can be supplied without changing card structure.',
+    media: (
+      <div
+        style={{
+          minHeight: 128,
+          background:
+            'linear-gradient(135deg, var(--p-color-surface-subtle), var(--p-color-action-primary-subtle))',
+        }}
+      />
+    ),
+  },
+};
+
+export const Interactive: Story = {
+  name: 'Interactive',
+  args: {
+    href: '#',
+    title: 'Open account summary',
+    description: 'The title is the link target while the full card receives hover and focus treatment.',
+  },
+};
+
+export const Densities: Story = {
+  name: 'Densities',
+  render: () => (
+    <div style={{ display: 'flex', alignItems: 'flex-start', gap: '1rem' }}>
+      <PCard density="compact" prefix="01" title="Compact" description="Tighter spacing." />
+      <PCard prefix="02" title="Default" description="Balanced spacing." />
+      <PCard density="spacious" prefix="03" title="Spacious" description="More breathing room." />
+    </div>
+  ),
+};
+
+export default meta;

--- a/src/components/PCard/PCard.stories.tsx
+++ b/src/components/PCard/PCard.stories.tsx
@@ -1,49 +1,74 @@
-import { type Meta, type StoryObj } from '@storybook/react';
-import { PButton } from '../PButton';
-import { PCard } from '.';
+import { type Meta, type StoryObj } from "@storybook/react";
+import { NewTabArrowIcon } from "../../icons";
+import { PButton } from "../PButton";
+import { PCard } from ".";
+
+function OperationsLinkMeta() {
+  return (
+    <>
+      <span>Operations</span>
+      <NewTabArrowIcon />
+    </>
+  );
+}
 
 const meta: Meta<typeof PCard> = {
-  title: 'Components/PCard',
+  title: "Components/PCard",
   component: PCard,
-  tags: ['autodocs'],
+  tags: ["autodocs"],
   parameters: {
-    layout: 'centered',
+    layout: "centered",
   },
   args: {
-    prefix: '01',
-    eyebrow: 'Operations',
-    title: 'Pipeline overview',
-    description: 'A compact summary card for scanning enterprise workflows.',
+    prefix: "01",
+    title: "Pipeline overview",
+    description: "A compact summary card for scanning enterprise workflows.",
   },
   argTypes: {
     prefix: {
-      description: 'Short leading metadata, often a sequence number.',
+      description: "Short leading metadata, often a sequence number.",
     },
     eyebrow: {
-      description: 'Short trailing metadata, category, or status text.',
+      description: "Short trailing metadata, category, or status text.",
     },
     title: {
-      description: 'Main card heading.',
+      description: "Main card heading.",
     },
     description: {
-      description: 'Optional supporting copy.',
+      description: "Optional supporting copy.",
     },
     media: {
-      description: 'Optional media/content rendered at the top of the card.',
+      description: "Optional media/content rendered at the top of the card.",
     },
     actions: {
-      description: 'Optional action slot rendered at the bottom.',
+      description: "Optional action slot rendered at the bottom.",
     },
     density: {
-      control: 'select',
-      options: ['compact', 'default', 'spacious'],
-      description: 'Controls the card padding and minimum height.',
+      control: "select",
+      options: ["compact", "default", "spacious"],
+      description: "Controls the card padding and minimum height.",
     },
     fullWidth: {
-      description: 'Expands the card to fill its container.',
+      description: "Expands the card to fill its container.",
+    },
+    width: {
+      description:
+        "Overrides the card width. Useful for fixed-width slider cards.",
+    },
+    minWidth: {
+      description:
+        "Sets the minimum card width for fixed card rows and slider items.",
+    },
+    height: {
+      description: "Overrides the card height for fixed-size card layouts.",
+    },
+    minHeight: {
+      description:
+        "Sets the minimum card height while still allowing taller content.",
     },
     href: {
-      description: 'When provided, the title becomes a link and the whole card gets an interactive state.',
+      description:
+        "When provided, the title becomes a link and the whole card gets an interactive state.",
     },
   },
 };
@@ -51,14 +76,15 @@ const meta: Meta<typeof PCard> = {
 type Story = StoryObj<typeof PCard>;
 
 export const Default: Story = {
-  name: 'Default',
+  name: "Default",
 };
 
 export const WithActions: Story = {
-  name: 'With Actions',
+  name: "With Actions",
   args: {
-    title: 'Contract queue',
-    description: 'Review pending approvals and route exceptions before the next close cycle.',
+    title: "Contract queue",
+    description:
+      "Review pending approvals and route exceptions before the next close cycle.",
     actions: (
       <>
         <PButton size="sm">Review</PButton>
@@ -70,49 +96,106 @@ export const WithActions: Story = {
   },
 };
 
-export const WithoutDescription: Story = {
-  name: 'Without Description',
+export const WithMetadata: Story = {
+  name: "With Metadata",
   args: {
-    prefix: '02',
-    eyebrow: 'Queue',
-    title: 'Title-only card',
-    description: undefined,
+    prefix: "01",
+    eyebrow: "Operations",
+    title: "Pipeline overview",
+    description: "A compact summary card for scanning enterprise workflows.",
+  },
+};
+
+export const WithoutDescription: Story = {
+  name: "Without Description",
+  args: {
+    prefix: "02",
+    eyebrow: "Queue",
+    title: "Title-only card",
+    description: null,
   },
 };
 
 export const WithMedia: Story = {
-  name: 'With Media',
+  name: "With Media",
   args: {
-    title: 'Account health',
-    description: 'A visual block can be supplied without changing card structure.',
+    title: "Account health",
+    description:
+      "A visual block can be supplied without changing card structure.",
     media: (
       <div
         style={{
           minHeight: 128,
           background:
-            'linear-gradient(135deg, var(--p-color-surface-subtle), var(--p-color-action-primary-subtle))',
+            "linear-gradient(135deg, var(--p-color-surface-subtle), var(--p-color-action-primary-subtle))",
         }}
       />
     ),
   },
 };
 
-export const Interactive: Story = {
-  name: 'Interactive',
+export const CustomWidth: Story = {
+  name: "Custom Width",
   args: {
-    href: '#',
-    title: 'Open account summary',
-    description: 'The title is the link target while the full card receives hover and focus treatment.',
+    width: 800,
+    prefix: "03",
+    title: "Wide title-only card",
+    description: null,
+  },
+};
+
+export const CustomHeight: Story = {
+  name: "Custom Height",
+  args: {
+    width: 320,
+    height: 240,
+    prefix: "04",
+    title: "Fixed height card",
+    description: "Height can be controlled for consistent card rows.",
+  },
+};
+
+export const MinSizing: Story = {
+  name: "Min Sizing",
+  args: {
+    minWidth: 360,
+    minHeight: 220,
+    prefix: "05",
+    title: "Minimum size card",
+    description:
+      "Minimum sizing keeps rows stable while still allowing content to grow.",
+  },
+};
+
+export const Interactive: Story = {
+  name: "Interactive",
+  args: {
+    href: "#",
+    prefix: "06",
+    eyebrow: <OperationsLinkMeta />,
+    title: "Open account summary",
+    description:
+      "The title is the link target while the full card receives hover and focus treatment.",
   },
 };
 
 export const Densities: Story = {
-  name: 'Densities',
+  name: "Densities",
   render: () => (
-    <div style={{ display: 'flex', alignItems: 'flex-start', gap: '1rem' }}>
-      <PCard density="compact" prefix="01" title="Compact" description="Tighter spacing." />
+    <div style={{ display: "flex", alignItems: "flex-start", gap: "1rem" }}>
+      <PCard
+        density="compact"
+        prefix="01"
+        title="Compact"
+        description="Tighter spacing."
+      />
       <PCard prefix="02" title="Default" description="Balanced spacing." />
-      <PCard density="spacious" prefix="03" title="Spacious" description="More breathing room." />
+      <PCard
+        density="spacious"
+        prefix="03"
+        title="Spacious"
+        description="More breathing room."
+      />
     </div>
   ),
 };

--- a/src/components/PCard/PCard.tsx
+++ b/src/components/PCard/PCard.tsx
@@ -1,4 +1,10 @@
-import { forwardRef, type AnchorHTMLAttributes, type HTMLAttributes, type ReactNode } from 'react';
+import {
+  forwardRef,
+  type AnchorHTMLAttributes,
+  type CSSProperties,
+  type HTMLAttributes,
+  type ReactNode,
+} from 'react';
 import cn from '../../utils/cn';
 import { PTypography } from '../PTypography';
 import './PCard.css';
@@ -15,23 +21,58 @@ type PCardBaseProps = {
   actions?: ReactNode;
   density?: PCardDensity;
   fullWidth?: boolean;
+  width?: CSSProperties['width'];
+  minWidth?: CSSProperties['minWidth'];
+  height?: CSSProperties['height'];
+  minHeight?: CSSProperties['minHeight'];
   className?: string;
+  style?: CSSProperties;
   children?: ReactNode;
 };
 
 type PCardArticleProps = PCardBaseProps &
-  Omit<HTMLAttributes<HTMLElement>, 'className' | 'children' | 'title'> & {
+  Omit<HTMLAttributes<HTMLElement>, 'className' | 'children' | 'style' | 'title'> & {
     href?: undefined;
   };
 
 type PCardAnchorProps = PCardBaseProps &
-  Omit<AnchorHTMLAttributes<HTMLAnchorElement>, 'className' | 'children' | 'title'> & {
+  Omit<AnchorHTMLAttributes<HTMLAnchorElement>, 'className' | 'children' | 'style' | 'title'> & {
     href: string;
   };
 
 export type PCardProps = PCardArticleProps | PCardAnchorProps;
 type PCardAnchorElementProps = Omit<PCardAnchorProps, keyof PCardBaseProps>;
 type PCardArticleElementProps = Omit<PCardArticleProps, keyof PCardBaseProps>;
+type PCardStyle = CSSProperties & {
+  '--p-card-width'?: CSSProperties['width'];
+  '--p-card-min-width'?: CSSProperties['minWidth'];
+  '--p-card-height'?: CSSProperties['height'];
+  '--p-card-min-height'?: CSSProperties['minHeight'];
+};
+
+function hasRenderableNode(node: ReactNode) {
+  return node !== null && node !== undefined && node !== false && node !== '';
+}
+
+function renderMetaNode(node: ReactNode, className: string) {
+  if (!hasRenderableNode(node)) {
+    return null;
+  }
+
+  if (typeof node === 'string' || typeof node === 'number') {
+    return (
+      <PTypography className={className} variant="body-wide">
+        {node}
+      </PTypography>
+    );
+  }
+
+  return <span className={cn(className, 'p-card__meta-custom')}>{node}</span>;
+}
+
+function getCardSizeValue(value: CSSProperties['width']) {
+  return typeof value === 'number' ? `${value}px` : value;
+}
 
 export const PCard = forwardRef<PCardRef, PCardProps>(
   (
@@ -44,7 +85,12 @@ export const PCard = forwardRef<PCardRef, PCardProps>(
       actions,
       density = 'default',
       fullWidth = false,
+      width,
+      minWidth,
+      height,
+      minHeight,
       className,
+      style,
       children,
       ...props
     },
@@ -55,25 +101,28 @@ export const PCard = forwardRef<PCardRef, PCardProps>(
       'p-card',
       density !== 'default' && `p-card--${density}`,
       fullWidth && 'p-card--full-width',
+      width !== undefined && 'p-card--custom-width',
+      minWidth !== undefined && 'p-card--custom-min-width',
+      height !== undefined && 'p-card--custom-height',
+      minHeight !== undefined && 'p-card--custom-min-height',
       isInteractive && 'p-card--interactive',
       className,
     );
+    const cardStyle: PCardStyle = {
+      ...style,
+      ...(width !== undefined ? { '--p-card-width': getCardSizeValue(width) } : {}),
+      ...(minWidth !== undefined ? { '--p-card-min-width': getCardSizeValue(minWidth) } : {}),
+      ...(height !== undefined ? { '--p-card-height': getCardSizeValue(height) } : {}),
+      ...(minHeight !== undefined ? { '--p-card-min-height': getCardSizeValue(minHeight) } : {}),
+    };
 
     const content = (
       <>
-        {media && <div className="p-card__media">{media}</div>}
-        {(prefix || eyebrow) && (
+        {hasRenderableNode(media) && <div className="p-card__media">{media}</div>}
+        {(hasRenderableNode(prefix) || hasRenderableNode(eyebrow)) && (
           <div className="p-card__meta">
-            {prefix && (
-              <PTypography className="p-card__prefix" variant="body-wide">
-                {prefix}
-              </PTypography>
-            )}
-            {eyebrow && (
-              <PTypography className="p-card__eyebrow" variant="body-wide">
-                {eyebrow}
-              </PTypography>
-            )}
+            {renderMetaNode(prefix, 'p-card__prefix')}
+            {renderMetaNode(eyebrow, 'p-card__eyebrow')}
           </div>
         )}
         <div className="p-card__body">
@@ -86,20 +135,20 @@ export const PCard = forwardRef<PCardRef, PCardProps>(
               title
             )}
           </PTypography>
-          {description ? (
+          {hasRenderableNode(description) ? (
             <PTypography className="p-card__description" variant="body">
               {description}
             </PTypography>
           ) : null}
         </div>
-        {children && <div className="p-card__content">{children}</div>}
-        {actions && <div className="p-card__actions">{actions}</div>}
+        {hasRenderableNode(children) && <div className="p-card__content">{children}</div>}
+        {hasRenderableNode(actions) && <div className="p-card__actions">{actions}</div>}
       </>
     );
 
     if (isInteractive) {
       return (
-        <article ref={ref as React.Ref<HTMLElement>} className={cardClassName}>
+        <article ref={ref as React.Ref<HTMLElement>} className={cardClassName} style={cardStyle}>
           {content}
         </article>
       );
@@ -110,6 +159,7 @@ export const PCard = forwardRef<PCardRef, PCardProps>(
         {...(props as PCardArticleElementProps)}
         ref={ref as React.Ref<HTMLElement>}
         className={cardClassName}
+        style={cardStyle}
       >
         {content}
       </article>

--- a/src/components/PCard/PCard.tsx
+++ b/src/components/PCard/PCard.tsx
@@ -1,0 +1,120 @@
+import { forwardRef, type AnchorHTMLAttributes, type HTMLAttributes, type ReactNode } from 'react';
+import cn from '../../utils/cn';
+import { PTypography } from '../PTypography';
+import './PCard.css';
+
+export type PCardDensity = 'compact' | 'default' | 'spacious';
+export type PCardRef = HTMLElement;
+
+type PCardBaseProps = {
+  prefix?: ReactNode;
+  eyebrow?: ReactNode;
+  title: ReactNode;
+  description?: ReactNode;
+  media?: ReactNode;
+  actions?: ReactNode;
+  density?: PCardDensity;
+  fullWidth?: boolean;
+  className?: string;
+  children?: ReactNode;
+};
+
+type PCardArticleProps = PCardBaseProps &
+  Omit<HTMLAttributes<HTMLElement>, 'className' | 'children' | 'title'> & {
+    href?: undefined;
+  };
+
+type PCardAnchorProps = PCardBaseProps &
+  Omit<AnchorHTMLAttributes<HTMLAnchorElement>, 'className' | 'children' | 'title'> & {
+    href: string;
+  };
+
+export type PCardProps = PCardArticleProps | PCardAnchorProps;
+type PCardAnchorElementProps = Omit<PCardAnchorProps, keyof PCardBaseProps>;
+type PCardArticleElementProps = Omit<PCardArticleProps, keyof PCardBaseProps>;
+
+export const PCard = forwardRef<PCardRef, PCardProps>(
+  (
+    {
+      prefix,
+      eyebrow,
+      title,
+      description,
+      media,
+      actions,
+      density = 'default',
+      fullWidth = false,
+      className,
+      children,
+      ...props
+    },
+    ref,
+  ) => {
+    const isInteractive = 'href' in props && typeof props.href === 'string';
+    const cardClassName = cn(
+      'p-card',
+      density !== 'default' && `p-card--${density}`,
+      fullWidth && 'p-card--full-width',
+      isInteractive && 'p-card--interactive',
+      className,
+    );
+
+    const content = (
+      <>
+        {media && <div className="p-card__media">{media}</div>}
+        {(prefix || eyebrow) && (
+          <div className="p-card__meta">
+            {prefix && (
+              <PTypography className="p-card__prefix" variant="body-wide">
+                {prefix}
+              </PTypography>
+            )}
+            {eyebrow && (
+              <PTypography className="p-card__eyebrow" variant="body-wide">
+                {eyebrow}
+              </PTypography>
+            )}
+          </div>
+        )}
+        <div className="p-card__body">
+          <PTypography as="h3" className="p-card__title" variant="heading">
+            {isInteractive ? (
+              <a {...(props as PCardAnchorElementProps)} className="p-card__link">
+                {title}
+              </a>
+            ) : (
+              title
+            )}
+          </PTypography>
+          {description ? (
+            <PTypography className="p-card__description" variant="body">
+              {description}
+            </PTypography>
+          ) : null}
+        </div>
+        {children && <div className="p-card__content">{children}</div>}
+        {actions && <div className="p-card__actions">{actions}</div>}
+      </>
+    );
+
+    if (isInteractive) {
+      return (
+        <article ref={ref as React.Ref<HTMLElement>} className={cardClassName}>
+          {content}
+        </article>
+      );
+    }
+
+    return (
+      <article
+        {...(props as PCardArticleElementProps)}
+        ref={ref as React.Ref<HTMLElement>}
+        className={cardClassName}
+      >
+        {content}
+      </article>
+    );
+  },
+);
+
+PCard.displayName = 'PCard';

--- a/src/components/PCard/index.ts
+++ b/src/components/PCard/index.ts
@@ -1,0 +1,1 @@
+export { PCard, type PCardProps, type PCardRef } from './PCard';

--- a/src/components/PDatePicker/PDatePicker.css
+++ b/src/components/PDatePicker/PDatePicker.css
@@ -1,0 +1,255 @@
+.p-date-picker {
+    --p-date-picker-bg: var(--p-color-surface);
+    --p-date-picker-bg-hover: var(--p-color-surface-subtle);
+    --p-date-picker-border: var(--p-color-border);
+    --p-date-picker-border-active: var(--p-color-border-strong);
+    --p-date-picker-text: var(--p-color-text);
+    --p-date-picker-text-muted: var(--p-color-text-muted);
+    --p-date-picker-accent: var(--p-color-action-primary);
+    --p-date-picker-accent-subtle: var(--p-color-action-primary-subtle);
+    --p-date-picker-error: var(--p-color-danger);
+    --p-date-picker-radius: var(--p-radius-sm);
+    --p-date-picker-panel-width: 20rem;
+    --p-date-picker-transition:
+        background-color var(--p-duration-fast) var(--p-ease-standard),
+        border-color var(--p-duration-fast) var(--p-ease-standard),
+        color var(--p-duration-fast) var(--p-ease-standard),
+        box-shadow var(--p-duration-fast) var(--p-ease-standard);
+
+    position: relative;
+    width: 100%;
+    max-width: 100%;
+    color: var(--p-date-picker-text);
+    font-family: var(--p-font-family-sans);
+}
+
+.p-date-picker__label {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: var(--p-space-3);
+    margin-block-end: var(--p-space-2);
+    color: var(--p-date-picker-text-muted);
+    font-size: var(--p-font-size-body-sm);
+    font-weight: var(--p-font-weight-medium);
+    line-height: var(--p-line-height-body-sm);
+}
+
+.p-date-picker__label-value {
+    min-width: 0;
+    overflow: hidden;
+    color: var(--p-date-picker-text);
+    font-size: var(--p-font-size-caption);
+    line-height: var(--p-line-height-caption);
+    text-align: end;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.p-date-picker__label-value--empty {
+    color: var(--p-date-picker-text-muted);
+}
+
+.p-date-picker__trigger,
+.p-date-picker__preset,
+.p-date-picker__nav,
+.p-date-picker__day {
+    border: 1px solid var(--p-date-picker-border);
+    background: var(--p-date-picker-bg);
+    color: var(--p-date-picker-text);
+    cursor: pointer;
+    font: inherit;
+    transition: var(--p-date-picker-transition);
+}
+
+.p-date-picker__trigger {
+    display: flex;
+    width: 100%;
+    min-height: var(--p-size-control-lg);
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--p-space-3);
+    border-radius: var(--p-date-picker-radius);
+    padding-inline: var(--p-space-4);
+    text-align: left;
+}
+
+.p-date-picker__trigger--empty {
+    color: var(--p-date-picker-text-muted);
+}
+
+.p-date-picker__trigger:hover,
+.p-date-picker__preset:hover,
+.p-date-picker__nav:hover,
+.p-date-picker__day:hover {
+    background: var(--p-date-picker-bg-hover);
+    border-color: var(--p-date-picker-border-active);
+}
+
+.p-date-picker__trigger:focus-visible,
+.p-date-picker__preset:focus-visible,
+.p-date-picker__nav:focus-visible,
+.p-date-picker__day:focus-visible {
+    outline: var(--p-focus-outline-width) solid transparent;
+    box-shadow: 0 0 0 var(--p-focus-ring-width) var(--p-focus-ring-color);
+}
+
+.p-date-picker__trigger:disabled,
+.p-date-picker__preset:disabled,
+.p-date-picker__nav:disabled,
+.p-date-picker__day:disabled {
+    cursor: not-allowed;
+    opacity: var(--p-opacity-disabled);
+}
+
+.p-date-picker__trigger-icon {
+    display: inline-flex;
+    width: var(--p-size-icon-md);
+    height: var(--p-size-icon-md);
+    flex: 0 0 auto;
+    color: var(--p-date-picker-text-muted);
+}
+
+.p-date-picker__trigger-icon svg,
+.p-date-picker__nav svg {
+    width: 100%;
+    height: 100%;
+}
+
+.p-date-picker__presets {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(min(100%, 7rem), 1fr));
+    gap: var(--p-space-2);
+}
+
+.p-date-picker__presets--fixed {
+    grid-template-columns: repeat(var(--p-date-picker-preset-columns), minmax(0, 1fr));
+}
+
+.p-date-picker__presets--fixed .p-date-picker__preset {
+    white-space: normal;
+}
+
+.p-date-picker__preset {
+    min-height: var(--p-size-control-md);
+    border-radius: var(--p-date-picker-radius);
+    font-size: var(--p-font-size-body-sm);
+    font-weight: var(--p-font-weight-medium);
+    line-height: var(--p-line-height-body-sm);
+    padding-inline: var(--p-space-3);
+    white-space: nowrap;
+}
+
+.p-date-picker__preset--active {
+    border-color: var(--p-date-picker-border-active);
+    background: var(--p-date-picker-accent-subtle);
+    color: var(--p-date-picker-accent);
+}
+
+.p-date-picker__panel {
+    z-index: 20;
+    width: var(--p-date-picker-panel-width);
+    max-width: calc(100vw - var(--p-space-8));
+    margin-block-start: var(--p-space-2);
+    border: 1px solid var(--p-date-picker-border);
+    border-radius: var(--p-date-picker-radius);
+    background: var(--p-date-picker-bg);
+    box-shadow: var(--p-shadow-lg);
+    padding: var(--p-space-3);
+}
+
+.p-date-picker__calendar-header {
+    display: grid;
+    grid-template-columns: var(--p-size-control-md) 1fr var(--p-size-control-md);
+    align-items: center;
+    gap: var(--p-space-2);
+    margin-block-end: var(--p-space-3);
+}
+
+.p-date-picker__month {
+    color: var(--p-date-picker-text);
+    font-size: var(--p-font-size-body-sm);
+    font-weight: var(--p-font-weight-medium);
+    line-height: var(--p-line-height-body-sm);
+    text-align: center;
+}
+
+.p-date-picker__nav {
+    display: inline-flex;
+    width: var(--p-size-control-md);
+    height: var(--p-size-control-md);
+    align-items: center;
+    justify-content: center;
+    border-radius: var(--p-date-picker-radius);
+    color: var(--p-date-picker-text-muted);
+}
+
+.p-date-picker__weekdays,
+.p-date-picker__grid {
+    display: grid;
+    grid-template-columns: repeat(7, minmax(0, 1fr));
+    gap: var(--p-space-1);
+}
+
+.p-date-picker__weekdays {
+    margin-block-end: var(--p-space-1);
+    color: var(--p-date-picker-text-muted);
+    font-size: var(--p-font-size-caption);
+    line-height: var(--p-line-height-caption);
+    text-align: center;
+}
+
+.p-date-picker__day {
+    aspect-ratio: 1;
+    min-width: 0;
+    border-color: transparent;
+    border-radius: var(--p-radius-xs);
+    font-size: var(--p-font-size-body-sm);
+    line-height: var(--p-line-height-body-sm);
+    padding: 0;
+}
+
+.p-date-picker__day--outside {
+    color: var(--p-date-picker-text-muted);
+}
+
+.p-date-picker__day--today {
+    border-color: var(--p-date-picker-border-active);
+}
+
+.p-date-picker__day--selected {
+    border-color: var(--p-date-picker-accent);
+    background: var(--p-date-picker-accent);
+    color: var(--p-color-text-inverse);
+}
+
+.p-date-picker__message {
+    margin-block-start: var(--p-space-1);
+    color: var(--p-date-picker-text-muted);
+    font-size: var(--p-font-size-caption);
+    line-height: var(--p-line-height-caption);
+}
+
+.p-date-picker__message--error {
+    color: var(--p-date-picker-error);
+}
+
+.p-date-picker--error .p-date-picker__trigger,
+.p-date-picker--error .p-date-picker__preset {
+    border-color: var(--p-date-picker-error);
+}
+
+.p-date-picker--disabled {
+    opacity: var(--p-opacity-disabled);
+}
+
+@media (max-width: 40rem) {
+    .p-date-picker {
+        max-width: 100%;
+    }
+
+    .p-date-picker__panel {
+        width: 100%;
+        max-width: 100%;
+    }
+}

--- a/src/components/PDatePicker/PDatePicker.stories.tsx
+++ b/src/components/PDatePicker/PDatePicker.stories.tsx
@@ -1,0 +1,186 @@
+import { type Meta, type StoryObj } from '@storybook/react';
+import { PDatePicker, PDatePickerPresets } from '.';
+import { PTextInput } from '../PTextInput';
+
+const meta: Meta<typeof PDatePicker> = {
+  title: 'Components/PDatePicker',
+  component: PDatePicker,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered',
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ width: 360 }}>
+        <Story />
+      </div>
+    ),
+  ],
+  args: {
+    label: 'Date',
+    locale: 'en-US',
+  },
+  argTypes: {
+    label: {
+      description: 'Visible field label.',
+    },
+    value: {
+      description: 'Controlled ISO date value in yyyy-mm-dd format.',
+    },
+    defaultValue: {
+      description: 'Initial ISO date value in yyyy-mm-dd format.',
+    },
+    presets: {
+      description: 'Optional quick date actions shown before the custom calendar trigger.',
+    },
+    customLabel: {
+      description: 'Label for the calendar-opening preset button.',
+    },
+    showCustom: {
+      description: 'Shows the custom calendar action when presets are present.',
+    },
+    presetColumns: {
+      control: 'select',
+      options: ['auto', 2, 3, 4],
+      description: 'Controls the preset grid column count. Use auto for responsive fitting.',
+    },
+    min: {
+      description: 'Minimum selectable ISO date.',
+    },
+    max: {
+      description: 'Maximum selectable ISO date.',
+    },
+    helperText: {
+      description: 'Shown below the picker when there is no error.',
+    },
+    isError: {
+      description: 'Puts the picker into an error state.',
+    },
+    errorMessage: {
+      description: 'Shown below the picker when `isError` is true.',
+    },
+  },
+};
+
+type Story = StoryObj<typeof PDatePicker>;
+
+export const Standard: Story = {
+  name: 'Standard',
+  args: {
+    label: 'Due date',
+    defaultValue: '2026-05-10',
+    helperText: 'Choose a date from the calendar.',
+  },
+};
+
+export const WithPresets: Story = {
+  name: 'With Presets',
+  args: {
+    label: 'Report date',
+    presets: [PDatePickerPresets.today, PDatePickerPresets.yesterday],
+    customLabel: 'Custom',
+    presetColumns: 3,
+    helperText: 'Use a quick date or choose a custom date.',
+  },
+};
+
+export const ManyPresets: Story = {
+  name: 'Many Presets',
+  args: {
+    label: 'Reporting date',
+    presets: [
+      PDatePickerPresets.today,
+      PDatePickerPresets.yesterday,
+      PDatePickerPresets.tomorrow,
+      PDatePickerPresets.startOfMonth,
+    ],
+    customLabel: 'Custom',
+    helperText: 'Auto layout adapts when teams expose more quick actions.',
+  },
+};
+
+export const AlternatePresets: Story = {
+  name: 'Alternate Presets',
+  args: {
+    label: 'Schedule date',
+    presets: [PDatePickerPresets.yesterday, PDatePickerPresets.tomorrow],
+    customLabel: 'Custom',
+    presetColumns: 3,
+  },
+};
+
+export const PresetsOnly: Story = {
+  name: 'Presets Only',
+  args: {
+    label: 'SLA date',
+    presets: [
+      PDatePickerPresets.today,
+      PDatePickerPresets.tomorrow,
+      PDatePickerPresets.startOfMonth,
+      PDatePickerPresets.endOfMonth,
+    ],
+    showCustom: false,
+    presetColumns: 2,
+    helperText: 'Restrict selection to approved operational dates.',
+  },
+};
+
+export const Empty: Story = {
+  name: 'Empty',
+  args: {
+    label: 'Start date',
+  },
+};
+
+export const WithBounds: Story = {
+  name: 'With Bounds',
+  args: {
+    label: 'Booking date',
+    defaultValue: '2026-05-10',
+    min: '2026-05-05',
+    max: '2026-05-20',
+    helperText: 'Only dates within the booking window can be selected.',
+  },
+};
+
+export const WithError: Story = {
+  name: 'With Error',
+  args: {
+    label: 'Contract date',
+    isError: true,
+    errorMessage: 'Select a valid contract date.',
+  },
+};
+
+export const SampleWithOtherFields: Story = {
+  name: 'Sample With Other Fields',
+  render: () => (
+    <div style={{ display: 'grid', gap: '1rem', width: 360 }}>
+      <PTextInput label="Project name" defaultValue="Enterprise rollout" />
+      <PDatePicker
+        label="Report date"
+        presets={[PDatePickerPresets.today, PDatePickerPresets.yesterday]}
+        customLabel="Custom"
+        presetColumns={3}
+        helperText="Opening the calendar expands the field area."
+      />
+      <PTextInput label="Owner" defaultValue="Operations" />
+      <PTextInput label="Reference" />
+    </div>
+  ),
+  parameters: {
+    layout: 'centered',
+  },
+  decorators: [(Story) => <Story />],
+};
+
+export const Disabled: Story = {
+  name: 'Disabled',
+  args: {
+    label: 'Locked date',
+    defaultValue: '2026-05-10',
+    disabled: true,
+  },
+};
+
+export default meta;

--- a/src/components/PDatePicker/PDatePicker.tsx
+++ b/src/components/PDatePicker/PDatePicker.tsx
@@ -1,0 +1,567 @@
+import {
+  forwardRef,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+  type ButtonHTMLAttributes,
+  type CSSProperties,
+  type HTMLAttributes,
+} from 'react';
+import cn from '../../utils/cn';
+import './PDatePicker.css';
+
+export type PDatePickerRef = HTMLDivElement;
+export type PDatePickerChangeSource = 'preset' | 'calendar';
+export type PDatePickerPresetColumns = 2 | 3 | 4 | 'auto';
+type FocusableElement = { focus: () => void };
+
+export type PDatePickerPreset = {
+  label: string;
+  value: string | Date | (() => string | Date);
+};
+
+export type PDatePickerProps = {
+  label: string;
+  value?: string;
+  defaultValue?: string;
+  onValueChange?: (
+    value: string,
+    details: { date: Date | null; source: PDatePickerChangeSource },
+  ) => void;
+  presets?: PDatePickerPreset[];
+  customLabel?: string;
+  showCustom?: boolean;
+  presetColumns?: PDatePickerPresetColumns;
+  placeholder?: string;
+  helperText?: string;
+  isError?: boolean;
+  errorMessage?: string;
+  min?: string;
+  max?: string;
+  name?: string;
+  disabled?: boolean;
+  readOnly?: boolean;
+  required?: boolean;
+  locale?: string;
+  weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6;
+  className?: string;
+} & Omit<HTMLAttributes<HTMLDivElement>, 'className' | 'defaultValue' | 'onChange'>;
+
+const dayFormatter = new Intl.DateTimeFormat(undefined, { weekday: 'short' });
+
+function toLocalDate(value: string | Date | null | undefined) {
+  if (!value) {
+    return null;
+  }
+
+  if (value instanceof Date) {
+    return Number.isNaN(value.getTime())
+      ? null
+      : new Date(value.getFullYear(), value.getMonth(), value.getDate());
+  }
+
+  const parts = value.split('-').map(Number);
+
+  if (parts.length !== 3 || parts.some(Number.isNaN)) {
+    return null;
+  }
+
+  const [year, month, day] = parts;
+  const date = new Date(year, month - 1, day);
+
+  if (date.getFullYear() !== year || date.getMonth() !== month - 1 || date.getDate() !== day) {
+    return null;
+  }
+
+  return date;
+}
+
+function toIsoDate(date: Date | null) {
+  if (!date) {
+    return '';
+  }
+
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+
+  return `${year}-${month}-${day}`;
+}
+
+function startOfMonth(date: Date) {
+  return new Date(date.getFullYear(), date.getMonth(), 1);
+}
+
+function endOfMonth(date: Date) {
+  return new Date(date.getFullYear(), date.getMonth() + 1, 0);
+}
+
+function addMonths(date: Date, months: number) {
+  return new Date(date.getFullYear(), date.getMonth() + months, 1);
+}
+
+function addMonthsClamped(date: Date, months: number) {
+  const monthStart = addMonths(date, months);
+  const lastDay = endOfMonth(monthStart).getDate();
+
+  return new Date(monthStart.getFullYear(), monthStart.getMonth(), Math.min(date.getDate(), lastDay));
+}
+
+function addDays(date: Date, days: number) {
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate() + days);
+}
+
+function isSameDay(a: Date | null, b: Date | null) {
+  return Boolean(a && b && toIsoDate(a) === toIsoDate(b));
+}
+
+function getToday() {
+  const today = new Date();
+  return new Date(today.getFullYear(), today.getMonth(), today.getDate());
+}
+
+function getCalendarDays(monthDate: Date, weekStartsOn: number) {
+  const monthStart = startOfMonth(monthDate);
+  const offset = (monthStart.getDay() - weekStartsOn + 7) % 7;
+  const gridStart = addDays(monthStart, -offset);
+
+  return Array.from({ length: 42 }, (_, index) => addDays(gridStart, index));
+}
+
+function resolvePresetDate(preset: PDatePickerPreset) {
+  const value = typeof preset.value === 'function' ? preset.value() : preset.value;
+  return toLocalDate(value);
+}
+
+function getMonthLabel(date: Date, locale?: string) {
+  return new Intl.DateTimeFormat(locale, { month: 'long', year: 'numeric' }).format(date);
+}
+
+function getDateLabel(date: Date, locale?: string) {
+  return new Intl.DateTimeFormat(locale, {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  }).format(date);
+}
+
+function getDayLabel(date: Date, locale?: string) {
+  return new Intl.DateTimeFormat(locale, {
+    weekday: 'long',
+    month: 'long',
+    day: 'numeric',
+    year: 'numeric',
+  }).format(date);
+}
+
+function getWeekdayLabels(weekStartsOn: number, locale?: string) {
+  const baseSunday = new Date(2024, 0, 7);
+
+  return Array.from({ length: 7 }, (_, index) => {
+    const date = addDays(baseSunday, weekStartsOn + index);
+    return dayFormatter.formatToParts(date).length
+      ? new Intl.DateTimeFormat(locale, { weekday: 'short' }).format(date)
+      : '';
+  });
+}
+
+function isBeforeDate(date: Date, minDate: Date | null) {
+  return Boolean(minDate && date.getTime() < minDate.getTime());
+}
+
+function isAfterDate(date: Date, maxDate: Date | null) {
+  return Boolean(maxDate && date.getTime() > maxDate.getTime());
+}
+
+function CalendarIcon() {
+  return (
+    <svg viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="1.75" aria-hidden="true">
+      <path d="M6 3v3" />
+      <path d="M14 3v3" />
+      <path d="M4 8h12" />
+      <path d="M5 5h10a1 1 0 0 1 1 1v10a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1V6a1 1 0 0 1 1-1Z" />
+    </svg>
+  );
+}
+
+function ChevronLeftIcon() {
+  return (
+    <svg viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="1.75" aria-hidden="true">
+      <path d="m12 5-5 5 5 5" />
+    </svg>
+  );
+}
+
+function ChevronRightIcon() {
+  return (
+    <svg viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="1.75" aria-hidden="true">
+      <path d="m8 5 5 5-5 5" />
+    </svg>
+  );
+}
+
+export const PDatePicker = forwardRef<PDatePickerRef, PDatePickerProps>(
+  (
+    {
+      label,
+      value,
+      defaultValue,
+      onValueChange,
+      presets = [],
+      customLabel = 'Custom',
+      showCustom = true,
+      presetColumns = 'auto',
+      placeholder = 'Select date',
+      helperText,
+      isError = false,
+      errorMessage,
+      min,
+      max,
+      name,
+      disabled = false,
+      readOnly = false,
+      required = false,
+      locale,
+      weekStartsOn = 0,
+      className,
+      id,
+      style,
+      ...props
+    },
+    ref,
+  ) => {
+    const generatedId = useId();
+    const rootId = id ?? generatedId;
+    const labelId = `${rootId}-label`;
+    const panelId = `${rootId}-panel`;
+    const helperId = `${rootId}-helper`;
+    const errorId = `${rootId}-error`;
+    const isControlled = value !== undefined;
+    const [internalValue, setInternalValue] = useState(defaultValue ?? '');
+    const [isOpen, setIsOpen] = useState(false);
+    const selectedValue = isControlled ? value : internalValue;
+    const selectedDate = toLocalDate(selectedValue);
+    const today = useMemo(getToday, []);
+    const minDate = toLocalDate(min);
+    const maxDate = toLocalDate(max);
+    const [visibleMonth, setVisibleMonth] = useState(() => startOfMonth(selectedDate ?? today));
+    const [focusedDate, setFocusedDate] = useState(() => selectedDate ?? today);
+    const calendarTriggerRef = useRef<FocusableElement | null>(null);
+    const dayRefs = useRef<Record<string, FocusableElement | null>>({});
+    const calendarDays = getCalendarDays(visibleMonth, weekStartsOn);
+    const weekdayLabels = getWeekdayLabels(weekStartsOn, locale);
+    const hasPresets = presets.length > 0;
+    const shouldRenderCustom = hasPresets ? showCustom : true;
+    const presetColumnsStyle =
+      presetColumns === 'auto'
+        ? undefined
+        : ({
+            '--p-date-picker-preset-columns': String(presetColumns),
+          } as CSSProperties);
+    const messageId = isError && errorMessage ? errorId : helperText ? helperId : undefined;
+    const displayValue = selectedDate ? getDateLabel(selectedDate, locale) : placeholder;
+    const selectedMatchesPreset = hasPresets
+      ? presets.some((preset) => isSameDay(resolvePresetDate(preset), selectedDate))
+      : false;
+    const isCustomActive = isOpen || Boolean(selectedDate && !selectedMatchesPreset);
+
+    useEffect(() => {
+      if (!isOpen) {
+        return;
+      }
+
+      dayRefs.current[toIsoDate(focusedDate)]?.focus();
+    }, [focusedDate, isOpen, visibleMonth]);
+
+    const setDateValue = (date: Date | null, source: PDatePickerChangeSource) => {
+      const nextValue = toIsoDate(date);
+
+      if (!isControlled) {
+        setInternalValue(nextValue);
+      }
+
+      if (date) {
+        setVisibleMonth(startOfMonth(date));
+      }
+
+      onValueChange?.(nextValue, { date, source });
+    };
+
+    const openCalendar = (trigger: HTMLButtonElement) => {
+      if (disabled || readOnly) {
+        return;
+      }
+
+      const nextFocusedDate = selectedDate ?? today;
+      calendarTriggerRef.current = trigger as unknown as FocusableElement;
+      setFocusedDate(nextFocusedDate);
+      setVisibleMonth(startOfMonth(nextFocusedDate));
+      setIsOpen(true);
+    };
+
+    const closeCalendar = (restoreFocus = false) => {
+      setIsOpen(false);
+
+      if (restoreFocus) {
+        calendarTriggerRef.current?.focus();
+      }
+    };
+
+    const handlePresetClick = (preset: PDatePickerPreset) => {
+      if (disabled || readOnly) {
+        return;
+      }
+
+      const presetDate = resolvePresetDate(preset);
+      setDateValue(presetDate, 'preset');
+      closeCalendar();
+    };
+
+    const handleDayClick = (date: Date) => {
+      if (disabled || readOnly || isBeforeDate(date, minDate) || isAfterDate(date, maxDate)) {
+        return;
+      }
+
+      setFocusedDate(date);
+      setDateValue(date, 'calendar');
+      closeCalendar(true);
+    };
+
+    const focusCalendarDate = (date: Date) => {
+      if (isBeforeDate(date, minDate) || isAfterDate(date, maxDate)) {
+        return;
+      }
+
+      setFocusedDate(date);
+      setVisibleMonth(startOfMonth(date));
+    };
+
+    const handleDayKeyDown =
+      (date: Date): ButtonHTMLAttributes<HTMLButtonElement>['onKeyDown'] =>
+      (event) => {
+        if (event.key === 'Escape') {
+          event.preventDefault();
+          closeCalendar(true);
+          return;
+        }
+
+        const weekOffset = (date.getDay() - weekStartsOn + 7) % 7;
+        const nextDateByKey: Record<string, Date> = {
+          ArrowLeft: addDays(date, -1),
+          ArrowRight: addDays(date, 1),
+          ArrowUp: addDays(date, -7),
+          ArrowDown: addDays(date, 7),
+          Home: addDays(date, -weekOffset),
+          End: addDays(date, 6 - weekOffset),
+          PageUp: addMonthsClamped(date, -1),
+          PageDown: addMonthsClamped(date, 1),
+        };
+        const nextDate = nextDateByKey[event.key];
+
+        if (!nextDate) {
+          return;
+        }
+
+        event.preventDefault();
+        focusCalendarDate(nextDate);
+      };
+
+    return (
+      <div
+        {...props}
+        ref={ref}
+        id={rootId}
+        style={presetColumnsStyle ? { ...style, ...presetColumnsStyle } : style}
+        className={cn(
+          'p-date-picker',
+          hasPresets && 'p-date-picker--with-presets',
+          isError && 'p-date-picker--error',
+          disabled && 'p-date-picker--disabled',
+          className,
+        )}
+      >
+        <div id={labelId} className="p-date-picker__label">
+          <span>{label}</span>
+          {hasPresets ? (
+            <span className={cn('p-date-picker__label-value', !selectedDate && 'p-date-picker__label-value--empty')}>
+              {displayValue}
+            </span>
+          ) : null}
+        </div>
+
+        {hasPresets ? (
+          <div
+            aria-describedby={messageId}
+            aria-labelledby={labelId}
+            className={cn(
+              'p-date-picker__presets',
+              presetColumns !== 'auto' && 'p-date-picker__presets--fixed',
+            )}
+            role="group"
+          >
+            {presets.map((preset) => {
+              const presetDate = resolvePresetDate(preset);
+              const isActive = isSameDay(presetDate, selectedDate);
+
+              return (
+                <button
+                  key={preset.label}
+                  type="button"
+                  className={cn('p-date-picker__preset', isActive && 'p-date-picker__preset--active')}
+                  disabled={disabled}
+                  aria-pressed={isActive}
+                  onClick={() => handlePresetClick(preset)}
+                >
+                  {preset.label}
+                </button>
+              );
+            })}
+            {shouldRenderCustom ? (
+              <button
+                type="button"
+                className={cn(
+                  'p-date-picker__preset',
+                  isCustomActive && 'p-date-picker__preset--active',
+                )}
+                disabled={disabled}
+                aria-controls={panelId}
+                aria-expanded={isOpen}
+                aria-pressed={isCustomActive}
+                onClick={(event) => (isOpen ? closeCalendar(true) : openCalendar(event.currentTarget))}
+              >
+                {customLabel}
+              </button>
+            ) : null}
+          </div>
+        ) : (
+          <button
+            type="button"
+            className={cn('p-date-picker__trigger', !selectedDate && 'p-date-picker__trigger--empty')}
+            disabled={disabled}
+            aria-controls={panelId}
+            aria-describedby={messageId}
+            aria-expanded={isOpen}
+            aria-haspopup="dialog"
+            aria-labelledby={labelId}
+            onClick={(event) => (isOpen ? closeCalendar(true) : openCalendar(event.currentTarget))}
+          >
+            <span>{displayValue}</span>
+            <span className="p-date-picker__trigger-icon">
+              <CalendarIcon />
+            </span>
+          </button>
+        )}
+
+        <input type="hidden" name={name} value={selectedValue ?? ''} required={required} />
+
+        {isOpen && (
+          <div
+            id={panelId}
+            className="p-date-picker__panel"
+            role="dialog"
+            aria-labelledby={`${panelId}-title`}
+            onKeyDown={(event) => {
+              if (event.key === 'Escape') {
+                closeCalendar();
+              }
+            }}
+          >
+            <div className="p-date-picker__calendar-header">
+              <button
+                type="button"
+                className="p-date-picker__nav"
+                aria-label="Previous month"
+                onClick={() => setVisibleMonth((date) => addMonths(date, -1))}
+              >
+                <ChevronLeftIcon />
+              </button>
+              <div id={`${panelId}-title`} className="p-date-picker__month">
+                {getMonthLabel(visibleMonth, locale)}
+              </div>
+              <button
+                type="button"
+                className="p-date-picker__nav"
+                aria-label="Next month"
+                onClick={() => setVisibleMonth((date) => addMonths(date, 1))}
+              >
+                <ChevronRightIcon />
+              </button>
+            </div>
+
+            <div className="p-date-picker__weekdays" aria-hidden="true">
+              {weekdayLabels.map((weekday) => (
+                <span key={weekday}>{weekday}</span>
+              ))}
+            </div>
+
+            <div className="p-date-picker__grid" role="grid" aria-labelledby={`${panelId}-title`}>
+              {calendarDays.map((date) => {
+                const isoDate = toIsoDate(date);
+                const isOutsideMonth = date.getMonth() !== visibleMonth.getMonth();
+                const isSelected = isSameDay(date, selectedDate);
+                const isToday = isSameDay(date, today);
+                const isDisabled = isBeforeDate(date, minDate) || isAfterDate(date, maxDate);
+
+                return (
+                  <button
+                    key={isoDate}
+                    ref={(node) => {
+                      dayRefs.current[isoDate] = node as unknown as FocusableElement | null;
+                    }}
+                    type="button"
+                    role="gridcell"
+                    data-date={isoDate}
+                    className={cn(
+                      'p-date-picker__day',
+                      isOutsideMonth && 'p-date-picker__day--outside',
+                      isToday && 'p-date-picker__day--today',
+                      isSelected && 'p-date-picker__day--selected',
+                    )}
+                    disabled={isDisabled}
+                    aria-label={getDayLabel(date, locale)}
+                    aria-selected={isSelected}
+                    tabIndex={isSameDay(date, focusedDate) ? 0 : -1}
+                    onClick={() => handleDayClick(date)}
+                    onKeyDown={handleDayKeyDown(date)}
+                  >
+                    {date.getDate()}
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+        )}
+
+        {isError && errorMessage ? (
+          <p id={errorId} role="alert" className="p-date-picker__message p-date-picker__message--error">
+            {errorMessage}
+          </p>
+        ) : null}
+
+        {!isError && helperText ? (
+          <p id={helperId} className="p-date-picker__message">
+            {helperText}
+          </p>
+        ) : null}
+      </div>
+    );
+  },
+);
+
+PDatePicker.displayName = 'PDatePicker';
+
+export const PDatePickerPresets = {
+  today: { label: 'Today', value: () => getToday() },
+  yesterday: { label: 'Yesterday', value: () => addDays(getToday(), -1) },
+  tomorrow: { label: 'Tomorrow', value: () => addDays(getToday(), 1) },
+  startOfMonth: { label: 'Start of month', value: () => startOfMonth(getToday()) },
+  endOfMonth: {
+    label: 'End of month',
+    value: () => {
+      const today = getToday();
+      return new Date(today.getFullYear(), today.getMonth() + 1, 0);
+    },
+  },
+} satisfies Record<string, PDatePickerPreset>;

--- a/src/components/PDatePicker/index.ts
+++ b/src/components/PDatePicker/index.ts
@@ -1,0 +1,9 @@
+export {
+  PDatePicker,
+  PDatePickerPresets,
+  type PDatePickerChangeSource,
+  type PDatePickerPreset,
+  type PDatePickerPresetColumns,
+  type PDatePickerProps,
+  type PDatePickerRef,
+} from './PDatePicker';

--- a/src/components/PDateRangePicker/PDateRangePicker.css
+++ b/src/components/PDateRangePicker/PDateRangePicker.css
@@ -1,0 +1,259 @@
+.p-date-range-picker {
+  --p-date-range-picker-bg: var(--p-color-surface);
+  --p-date-range-picker-bg-hover: var(--p-color-surface-subtle);
+  --p-date-range-picker-border: var(--p-color-border);
+  --p-date-range-picker-border-active: var(--p-color-border-strong);
+  --p-date-range-picker-text: var(--p-color-text);
+  --p-date-range-picker-text-muted: var(--p-color-text-muted);
+  --p-date-range-picker-accent: var(--p-color-action-primary);
+  --p-date-range-picker-accent-subtle: var(--p-color-action-primary-subtle);
+  --p-date-range-picker-error: var(--p-color-danger);
+  --p-date-range-picker-radius: var(--p-radius-sm);
+  --p-date-range-picker-panel-width: 20rem;
+  --p-date-range-picker-transition: background-color var(--p-duration-fast) var(--p-ease-standard),
+    border-color var(--p-duration-fast) var(--p-ease-standard),
+    color var(--p-duration-fast) var(--p-ease-standard),
+    box-shadow var(--p-duration-fast) var(--p-ease-standard);
+
+  position: relative;
+  width: 100%;
+  max-width: 100%;
+  color: var(--p-date-range-picker-text);
+  font-family: var(--p-font-family-sans);
+}
+
+.p-date-range-picker__label {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--p-space-3);
+  margin-block-end: var(--p-space-2);
+  color: var(--p-date-range-picker-text-muted);
+  font-size: var(--p-font-size-body-sm);
+  font-weight: var(--p-font-weight-medium);
+  line-height: var(--p-line-height-body-sm);
+}
+
+.p-date-range-picker__label-value {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--p-date-range-picker-text);
+  font-size: var(--p-font-size-caption);
+  line-height: var(--p-line-height-caption);
+  text-align: end;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.p-date-range-picker__label-value--empty {
+  color: var(--p-date-range-picker-text-muted);
+}
+
+.p-date-range-picker__trigger,
+.p-date-range-picker__preset,
+.p-date-range-picker__nav,
+.p-date-range-picker__day {
+  border: 1px solid var(--p-date-range-picker-border);
+  background: var(--p-date-range-picker-bg);
+  color: var(--p-date-range-picker-text);
+  cursor: pointer;
+  font: inherit;
+  transition: var(--p-date-range-picker-transition);
+}
+
+.p-date-range-picker__trigger {
+  display: flex;
+  width: 100%;
+  min-height: var(--p-size-control-lg);
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--p-space-3);
+  border-radius: var(--p-date-range-picker-radius);
+  padding-inline: var(--p-space-4);
+  text-align: left;
+}
+
+.p-date-range-picker__trigger--empty {
+  color: var(--p-date-range-picker-text-muted);
+}
+
+.p-date-range-picker__trigger:hover,
+.p-date-range-picker__preset:hover,
+.p-date-range-picker__nav:hover,
+.p-date-range-picker__day:hover {
+  background: var(--p-date-range-picker-bg-hover);
+  border-color: var(--p-date-range-picker-border-active);
+}
+
+.p-date-range-picker__trigger:focus-visible,
+.p-date-range-picker__preset:focus-visible,
+.p-date-range-picker__nav:focus-visible,
+.p-date-range-picker__day:focus-visible {
+  outline: var(--p-focus-outline-width) solid transparent;
+  box-shadow: 0 0 0 var(--p-focus-ring-width) var(--p-focus-ring-color);
+}
+
+.p-date-range-picker__trigger:disabled,
+.p-date-range-picker__preset:disabled,
+.p-date-range-picker__nav:disabled,
+.p-date-range-picker__day:disabled {
+  cursor: not-allowed;
+  opacity: var(--p-opacity-disabled);
+}
+
+.p-date-range-picker__trigger-icon {
+  display: inline-flex;
+  width: var(--p-size-icon-md);
+  height: var(--p-size-icon-md);
+  flex: 0 0 auto;
+  color: var(--p-date-range-picker-text-muted);
+}
+
+.p-date-range-picker__trigger-icon svg,
+.p-date-range-picker__nav svg {
+  width: 100%;
+  height: 100%;
+}
+
+.p-date-range-picker__presets {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 7rem), 1fr));
+  gap: var(--p-space-2);
+}
+
+.p-date-range-picker__presets--fixed {
+  grid-template-columns: repeat(var(--p-date-range-picker-preset-columns), minmax(0, 1fr));
+}
+
+.p-date-range-picker__presets--fixed .p-date-range-picker__preset {
+  white-space: normal;
+}
+
+.p-date-range-picker__preset {
+  min-height: var(--p-size-control-md);
+  border-radius: var(--p-date-range-picker-radius);
+  font-size: var(--p-font-size-body-sm);
+  font-weight: var(--p-font-weight-medium);
+  line-height: var(--p-line-height-body-sm);
+  padding-inline: var(--p-space-3);
+  white-space: nowrap;
+}
+
+.p-date-range-picker__preset--active {
+  border-color: var(--p-date-range-picker-border-active);
+  background: var(--p-date-range-picker-accent-subtle);
+  color: var(--p-date-range-picker-accent);
+}
+
+.p-date-range-picker__panel {
+  z-index: 20;
+  width: var(--p-date-range-picker-panel-width);
+  max-width: calc(100vw - var(--p-space-8));
+  margin-block-start: var(--p-space-2);
+  border: 1px solid var(--p-date-range-picker-border);
+  border-radius: var(--p-date-range-picker-radius);
+  background: var(--p-date-range-picker-bg);
+  box-shadow: var(--p-shadow-lg);
+  padding: var(--p-space-3);
+}
+
+.p-date-range-picker__calendar-header {
+  display: grid;
+  grid-template-columns: var(--p-size-control-md) 1fr var(--p-size-control-md);
+  align-items: center;
+  gap: var(--p-space-2);
+  margin-block-end: var(--p-space-3);
+}
+
+.p-date-range-picker__month {
+  color: var(--p-date-range-picker-text);
+  font-size: var(--p-font-size-body-sm);
+  font-weight: var(--p-font-weight-medium);
+  line-height: var(--p-line-height-body-sm);
+  text-align: center;
+}
+
+.p-date-range-picker__nav {
+  display: inline-flex;
+  width: var(--p-size-control-md);
+  height: var(--p-size-control-md);
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--p-date-range-picker-radius);
+  color: var(--p-date-range-picker-text-muted);
+}
+
+.p-date-range-picker__weekdays,
+.p-date-range-picker__grid {
+  display: grid;
+  grid-template-columns: repeat(7, minmax(0, 1fr));
+  gap: var(--p-space-1);
+}
+
+.p-date-range-picker__weekdays {
+  margin-block-end: var(--p-space-1);
+  color: var(--p-date-range-picker-text-muted);
+  font-size: var(--p-font-size-caption);
+  line-height: var(--p-line-height-caption);
+  text-align: center;
+}
+
+.p-date-range-picker__day {
+  aspect-ratio: 1;
+  min-width: 0;
+  border-color: transparent;
+  border-radius: var(--p-radius-xs);
+  font-size: var(--p-font-size-body-sm);
+  line-height: var(--p-line-height-body-sm);
+  padding: 0;
+}
+
+.p-date-range-picker__day--outside {
+  color: var(--p-date-range-picker-text-muted);
+}
+
+.p-date-range-picker__day--today {
+  border-color: var(--p-date-range-picker-border-active);
+}
+
+.p-date-range-picker__day--in-range {
+  background: var(--p-date-range-picker-accent-subtle);
+  color: var(--p-date-range-picker-accent);
+}
+
+.p-date-range-picker__day--selected {
+  border-color: var(--p-date-range-picker-accent);
+  background: var(--p-date-range-picker-accent);
+  color: var(--p-color-text-inverse);
+}
+
+.p-date-range-picker__message {
+  margin-block-start: var(--p-space-1);
+  color: var(--p-date-range-picker-text-muted);
+  font-size: var(--p-font-size-caption);
+  line-height: var(--p-line-height-caption);
+}
+
+.p-date-range-picker__message--error {
+  color: var(--p-date-range-picker-error);
+}
+
+.p-date-range-picker--error .p-date-range-picker__trigger,
+.p-date-range-picker--error .p-date-range-picker__preset {
+  border-color: var(--p-date-range-picker-error);
+}
+
+.p-date-range-picker--disabled {
+  opacity: var(--p-opacity-disabled);
+}
+
+@media (max-width: 40rem) {
+  .p-date-range-picker {
+    max-width: 100%;
+  }
+
+  .p-date-range-picker__panel {
+    width: 100%;
+    max-width: 100%;
+  }
+}

--- a/src/components/PDateRangePicker/PDateRangePicker.stories.tsx
+++ b/src/components/PDateRangePicker/PDateRangePicker.stories.tsx
@@ -1,0 +1,156 @@
+import { type Meta, type StoryObj } from "@storybook/react";
+import { PDateRangePicker, PDateRangePickerPresets } from ".";
+
+const meta: Meta<typeof PDateRangePicker> = {
+  title: "Components/PDateRangePicker",
+  component: PDateRangePicker,
+  tags: ["autodocs"],
+  parameters: {
+    layout: "centered",
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ width: 360 }}>
+        <Story />
+      </div>
+    ),
+  ],
+  args: {
+    label: "Date range",
+    locale: "en-US",
+  },
+  argTypes: {
+    label: {
+      description: "Visible field label.",
+    },
+    value: {
+      description: "Controlled ISO date range.",
+    },
+    defaultValue: {
+      description: "Initial ISO date range.",
+    },
+    presets: {
+      description:
+        "Optional quick range actions shown before the custom calendar trigger.",
+    },
+    customLabel: {
+      description: "Label for the calendar-opening preset button.",
+    },
+    showCustom: {
+      description: "Shows the custom calendar action when presets are present.",
+    },
+    presetColumns: {
+      control: "select",
+      options: ["auto", 2, 3, 4],
+      description:
+        "Controls the preset grid column count. Use auto for responsive fitting.",
+    },
+    min: {
+      description: "Minimum selectable ISO date.",
+    },
+    max: {
+      description: "Maximum selectable ISO date.",
+    },
+    helperText: {
+      description: "Shown below the picker when there is no error.",
+    },
+    isError: {
+      description: "Puts the picker into an error state.",
+    },
+    errorMessage: {
+      description: "Shown below the picker when `isError` is true.",
+    },
+  },
+};
+
+type Story = StoryObj<typeof PDateRangePicker>;
+
+export const Standard: Story = {
+  name: "Standard",
+  args: {
+    label: "Report range",
+    defaultValue: { start: "2026-05-01", end: "2026-05-10" },
+    helperText: "Choose a start and end date.",
+  },
+};
+
+export const WithPresets: Story = {
+  name: "With Presets",
+  args: {
+    label: "Analytics range",
+    presets: [PDateRangePickerPresets.last7Days, PDateRangePickerPresets.thisMonth],
+    customLabel: "Custom",
+    presetColumns: 3,
+    helperText: "Use a quick range or choose a custom range.",
+  },
+};
+
+export const ManyPresets: Story = {
+  name: "Many Presets",
+  args: {
+    label: "Analytics range",
+    presets: [
+      PDateRangePickerPresets.last7Days,
+      PDateRangePickerPresets.last14Days,
+      PDateRangePickerPresets.last30Days,
+      PDateRangePickerPresets.thisMonth,
+    ],
+    customLabel: "Custom",
+    helperText: "Auto layout adapts when teams expose more quick ranges.",
+  },
+};
+
+export const PresetsOnly: Story = {
+  name: "Presets Only",
+  args: {
+    label: "Analytics range",
+    presets: [
+      PDateRangePickerPresets.last7Days,
+      PDateRangePickerPresets.last14Days,
+      PDateRangePickerPresets.last30Days,
+      PDateRangePickerPresets.monthToDate,
+      PDateRangePickerPresets.yearToDate,
+    ],
+    showCustom: false,
+    presetColumns: 2,
+    helperText: "Restrict the report to approved enterprise ranges.",
+  },
+};
+
+export const Empty: Story = {
+  name: "Empty",
+  args: {
+    label: "Booking range",
+  },
+};
+
+export const WithBounds: Story = {
+  name: "With Bounds",
+  args: {
+    label: "Booking window",
+    defaultValue: { start: "2026-05-10", end: "2026-05-15" },
+    min: "2026-05-05",
+    max: "2026-05-20",
+    helperText: "Only dates within the booking window can be selected.",
+  },
+};
+
+export const WithError: Story = {
+  name: "With Error",
+  args: {
+    label: "Contract range",
+    isError: true,
+    errorMessage: "Select a valid start and end date.",
+  },
+};
+
+export const Disabled: Story = {
+  name: "Disabled",
+  args: {
+    label: "Locked range",
+    defaultValue: { start: "2026-05-01", end: "2026-05-10" },
+    disabled: true,
+  },
+};
+
+export default meta;

--- a/src/components/PDateRangePicker/PDateRangePicker.tsx
+++ b/src/components/PDateRangePicker/PDateRangePicker.tsx
@@ -1,0 +1,726 @@
+import {
+  forwardRef,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+  type ButtonHTMLAttributes,
+  type CSSProperties,
+  type HTMLAttributes,
+} from 'react';
+import cn from '../../utils/cn';
+import './PDateRangePicker.css';
+
+export type PDateRangePickerRef = HTMLDivElement;
+export type PDateRangePickerChangeSource = 'preset' | 'calendar';
+export type PDateRangePickerPresetColumns = 2 | 3 | 4 | 'auto';
+type FocusableElement = { focus: () => void };
+
+export type PDateRangeValue = {
+  start?: string;
+  end?: string;
+};
+
+export type PDateRangePickerPreset = {
+  label: string;
+  value: PDateRangeValue | (() => PDateRangeValue);
+};
+
+export type PDateRangePickerProps = {
+  label: string;
+  value?: PDateRangeValue;
+  defaultValue?: PDateRangeValue;
+  onValueChange?: (
+    value: PDateRangeValue,
+    details: { startDate: Date | null; endDate: Date | null; source: PDateRangePickerChangeSource },
+  ) => void;
+  presets?: PDateRangePickerPreset[];
+  customLabel?: string;
+  showCustom?: boolean;
+  presetColumns?: PDateRangePickerPresetColumns;
+  placeholder?: string;
+  helperText?: string;
+  isError?: boolean;
+  errorMessage?: string;
+  min?: string;
+  max?: string;
+  nameStart?: string;
+  nameEnd?: string;
+  disabled?: boolean;
+  readOnly?: boolean;
+  required?: boolean;
+  locale?: string;
+  weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6;
+  className?: string;
+} & Omit<HTMLAttributes<HTMLDivElement>, 'className' | 'defaultValue' | 'onChange'>;
+
+const dayFormatter = new Intl.DateTimeFormat(undefined, { weekday: 'short' });
+
+function toLocalDate(value: string | Date | null | undefined) {
+  if (!value) {
+    return null;
+  }
+
+  if (value instanceof Date) {
+    return Number.isNaN(value.getTime())
+      ? null
+      : new Date(value.getFullYear(), value.getMonth(), value.getDate());
+  }
+
+  const parts = value.split('-').map(Number);
+
+  if (parts.length !== 3 || parts.some(Number.isNaN)) {
+    return null;
+  }
+
+  const [year, month, day] = parts;
+  const date = new Date(year, month - 1, day);
+
+  if (date.getFullYear() !== year || date.getMonth() !== month - 1 || date.getDate() !== day) {
+    return null;
+  }
+
+  return date;
+}
+
+function toIsoDate(date: Date | null) {
+  if (!date) {
+    return '';
+  }
+
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+
+  return `${year}-${month}-${day}`;
+}
+
+function startOfMonth(date: Date) {
+  return new Date(date.getFullYear(), date.getMonth(), 1);
+}
+
+function endOfMonth(date: Date) {
+  return new Date(date.getFullYear(), date.getMonth() + 1, 0);
+}
+
+function addMonths(date: Date, months: number) {
+  return new Date(date.getFullYear(), date.getMonth() + months, 1);
+}
+
+function addMonthsClamped(date: Date, months: number) {
+  const monthStart = addMonths(date, months);
+  const lastDay = endOfMonth(monthStart).getDate();
+
+  return new Date(monthStart.getFullYear(), monthStart.getMonth(), Math.min(date.getDate(), lastDay));
+}
+
+function addDays(date: Date, days: number) {
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate() + days);
+}
+
+function getToday() {
+  const today = new Date();
+  return new Date(today.getFullYear(), today.getMonth(), today.getDate());
+}
+
+function getCalendarDays(monthDate: Date, weekStartsOn: number) {
+  const monthStart = startOfMonth(monthDate);
+  const offset = (monthStart.getDay() - weekStartsOn + 7) % 7;
+  const gridStart = addDays(monthStart, -offset);
+
+  return Array.from({ length: 42 }, (_, index) => addDays(gridStart, index));
+}
+
+function getMonthLabel(date: Date, locale?: string) {
+  return new Intl.DateTimeFormat(locale, { month: 'long', year: 'numeric' }).format(date);
+}
+
+function getDateLabel(date: Date, locale?: string) {
+  return new Intl.DateTimeFormat(locale, {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  }).format(date);
+}
+
+function getDayLabel(date: Date, locale?: string) {
+  return new Intl.DateTimeFormat(locale, {
+    weekday: 'long',
+    month: 'long',
+    day: 'numeric',
+    year: 'numeric',
+  }).format(date);
+}
+
+function getWeekdayLabels(weekStartsOn: number, locale?: string) {
+  const baseSunday = new Date(2024, 0, 7);
+
+  return Array.from({ length: 7 }, (_, index) => {
+    const date = addDays(baseSunday, weekStartsOn + index);
+    return dayFormatter.formatToParts(date).length
+      ? new Intl.DateTimeFormat(locale, { weekday: 'short' }).format(date)
+      : '';
+  });
+}
+
+function isSameDay(a: Date | null, b: Date | null) {
+  return Boolean(a && b && toIsoDate(a) === toIsoDate(b));
+}
+
+function isBeforeDate(date: Date, minDate: Date | null) {
+  return Boolean(minDate && date.getTime() < minDate.getTime());
+}
+
+function isAfterDate(date: Date, maxDate: Date | null) {
+  return Boolean(maxDate && date.getTime() > maxDate.getTime());
+}
+
+function isInRange(date: Date, startDate: Date | null, endDate: Date | null) {
+  return Boolean(startDate && endDate && date > startDate && date < endDate);
+}
+
+function normalizeRange(startDate: Date | null, endDate: Date | null): PDateRangeValue {
+  if (!startDate && !endDate) {
+    return {};
+  }
+
+  if (startDate && endDate && endDate < startDate) {
+    return {
+      start: toIsoDate(endDate),
+      end: toIsoDate(startDate),
+    };
+  }
+
+  return {
+    start: toIsoDate(startDate),
+    end: toIsoDate(endDate),
+  };
+}
+
+function resolvePresetRange(preset: PDateRangePickerPreset) {
+  return typeof preset.value === 'function' ? preset.value() : preset.value;
+}
+
+function getRangeDates(value: PDateRangeValue | undefined) {
+  return {
+    startDate: toLocalDate(value?.start),
+    endDate: toLocalDate(value?.end),
+  };
+}
+
+function isSameRange(a: PDateRangeValue | undefined, b: PDateRangeValue | undefined) {
+  return Boolean(a?.start && a?.end && a.start === b?.start && a.end === b?.end);
+}
+
+function getRangeLabel(value: PDateRangeValue | undefined, placeholder: string, locale?: string) {
+  const { startDate, endDate } = getRangeDates(value);
+
+  if (startDate && endDate) {
+    return `${getDateLabel(startDate, locale)} - ${getDateLabel(endDate, locale)}`;
+  }
+
+  if (startDate) {
+    return `${getDateLabel(startDate, locale)} -`;
+  }
+
+  if (endDate) {
+    return `- ${getDateLabel(endDate, locale)}`;
+  }
+
+  return placeholder;
+}
+
+function CalendarIcon() {
+  return (
+    <svg viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="1.75" aria-hidden="true">
+      <path d="M6 3v3" />
+      <path d="M14 3v3" />
+      <path d="M4 8h12" />
+      <path d="M5 5h10a1 1 0 0 1 1 1v10a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1V6a1 1 0 0 1 1-1Z" />
+    </svg>
+  );
+}
+
+function ChevronLeftIcon() {
+  return (
+    <svg viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="1.75" aria-hidden="true">
+      <path d="m12 5-5 5 5 5" />
+    </svg>
+  );
+}
+
+function ChevronRightIcon() {
+  return (
+    <svg viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="1.75" aria-hidden="true">
+      <path d="m8 5 5 5-5 5" />
+    </svg>
+  );
+}
+
+export const PDateRangePicker = forwardRef<PDateRangePickerRef, PDateRangePickerProps>(
+  (
+    {
+      label,
+      value,
+      defaultValue,
+      onValueChange,
+      presets = [],
+      customLabel = 'Custom',
+      showCustom = true,
+      presetColumns = 'auto',
+      placeholder = 'Select range',
+      helperText,
+      isError = false,
+      errorMessage,
+      min,
+      max,
+      nameStart,
+      nameEnd,
+      disabled = false,
+      readOnly = false,
+      required = false,
+      locale,
+      weekStartsOn = 0,
+      className,
+      id,
+      style,
+      ...props
+    },
+    ref,
+  ) => {
+    const generatedId = useId();
+    const rootId = id ?? generatedId;
+    const labelId = `${rootId}-label`;
+    const panelId = `${rootId}-panel`;
+    const helperId = `${rootId}-helper`;
+    const errorId = `${rootId}-error`;
+    const isControlled = value !== undefined;
+    const [internalValue, setInternalValue] = useState<PDateRangeValue>(defaultValue ?? {});
+    const [isOpen, setIsOpen] = useState(false);
+    const selectedValue = isControlled ? value : internalValue;
+    const { startDate, endDate } = getRangeDates(selectedValue);
+    const today = useMemo(getToday, []);
+    const minDate = toLocalDate(min);
+    const maxDate = toLocalDate(max);
+    const [visibleMonth, setVisibleMonth] = useState(() => startOfMonth(startDate ?? today));
+    const [focusedDate, setFocusedDate] = useState(() => startDate ?? today);
+    const calendarTriggerRef = useRef<FocusableElement | null>(null);
+    const dayRefs = useRef<Record<string, FocusableElement | null>>({});
+    const calendarDays = getCalendarDays(visibleMonth, weekStartsOn);
+    const weekdayLabels = getWeekdayLabels(weekStartsOn, locale);
+    const hasPresets = presets.length > 0;
+    const shouldRenderCustom = hasPresets ? showCustom : true;
+    const presetColumnsStyle =
+      presetColumns === 'auto'
+        ? undefined
+        : ({
+            '--p-date-range-picker-preset-columns': String(presetColumns),
+          } as CSSProperties);
+    const hasCompleteRange = Boolean(selectedValue?.start && selectedValue?.end);
+    const messageId = isError && errorMessage ? errorId : helperText ? helperId : undefined;
+    const displayValue = getRangeLabel(selectedValue, placeholder, locale);
+    const selectedMatchesPreset = hasPresets
+      ? presets.some((preset) => isSameRange(resolvePresetRange(preset), selectedValue))
+      : false;
+    const isCustomActive = isOpen || Boolean(hasCompleteRange && !selectedMatchesPreset);
+
+    useEffect(() => {
+      if (!isOpen) {
+        return;
+      }
+
+      dayRefs.current[toIsoDate(focusedDate)]?.focus();
+    }, [focusedDate, isOpen, visibleMonth]);
+
+    const setRangeValue = (range: PDateRangeValue, source: PDateRangePickerChangeSource) => {
+      const { startDate: nextStartDate, endDate: nextEndDate } = getRangeDates(range);
+      const normalizedRange = normalizeRange(nextStartDate, nextEndDate);
+
+      if (!isControlled) {
+        setInternalValue(normalizedRange);
+      }
+
+      const normalizedDates = getRangeDates(normalizedRange);
+
+      if (normalizedDates.startDate) {
+        setVisibleMonth(startOfMonth(normalizedDates.startDate));
+      }
+
+      onValueChange?.(normalizedRange, {
+        startDate: normalizedDates.startDate,
+        endDate: normalizedDates.endDate,
+        source,
+      });
+    };
+
+    const openCalendar = (trigger: HTMLButtonElement) => {
+      if (disabled || readOnly) {
+        return;
+      }
+
+      const nextFocusedDate = startDate ?? today;
+      calendarTriggerRef.current = trigger as unknown as FocusableElement;
+      setFocusedDate(nextFocusedDate);
+      setVisibleMonth(startOfMonth(nextFocusedDate));
+      setIsOpen(true);
+    };
+
+    const closeCalendar = (restoreFocus = false) => {
+      setIsOpen(false);
+
+      if (restoreFocus) {
+        calendarTriggerRef.current?.focus();
+      }
+    };
+
+    const handlePresetClick = (preset: PDateRangePickerPreset) => {
+      if (disabled || readOnly) {
+        return;
+      }
+
+      setRangeValue(resolvePresetRange(preset), 'preset');
+      closeCalendar();
+    };
+
+    const handleDayClick = (date: Date) => {
+      if (disabled || readOnly || isBeforeDate(date, minDate) || isAfterDate(date, maxDate)) {
+        return;
+      }
+
+      if (!startDate || endDate) {
+        setFocusedDate(date);
+        setRangeValue({ start: toIsoDate(date), end: '' }, 'calendar');
+        return;
+      }
+
+      setFocusedDate(date);
+      setRangeValue({ start: toIsoDate(startDate), end: toIsoDate(date) }, 'calendar');
+      closeCalendar(true);
+    };
+
+    const focusCalendarDate = (date: Date) => {
+      if (isBeforeDate(date, minDate) || isAfterDate(date, maxDate)) {
+        return;
+      }
+
+      setFocusedDate(date);
+      setVisibleMonth(startOfMonth(date));
+    };
+
+    const handleDayKeyDown =
+      (date: Date): ButtonHTMLAttributes<HTMLButtonElement>['onKeyDown'] =>
+      (event) => {
+        if (event.key === 'Escape') {
+          event.preventDefault();
+          closeCalendar(true);
+          return;
+        }
+
+        const weekOffset = (date.getDay() - weekStartsOn + 7) % 7;
+        const nextDateByKey: Record<string, Date> = {
+          ArrowLeft: addDays(date, -1),
+          ArrowRight: addDays(date, 1),
+          ArrowUp: addDays(date, -7),
+          ArrowDown: addDays(date, 7),
+          Home: addDays(date, -weekOffset),
+          End: addDays(date, 6 - weekOffset),
+          PageUp: addMonthsClamped(date, -1),
+          PageDown: addMonthsClamped(date, 1),
+        };
+        const nextDate = nextDateByKey[event.key];
+
+        if (!nextDate) {
+          return;
+        }
+
+        event.preventDefault();
+        focusCalendarDate(nextDate);
+      };
+
+    return (
+      <div
+        {...props}
+        ref={ref}
+        id={rootId}
+        style={presetColumnsStyle ? { ...style, ...presetColumnsStyle } : style}
+        className={cn(
+          'p-date-range-picker',
+          hasPresets && 'p-date-range-picker--with-presets',
+          isError && 'p-date-range-picker--error',
+          disabled && 'p-date-range-picker--disabled',
+          className,
+        )}
+      >
+        <div id={labelId} className="p-date-range-picker__label">
+          <span>{label}</span>
+          <span
+            className={cn(
+              'p-date-range-picker__label-value',
+              !hasCompleteRange && 'p-date-range-picker__label-value--empty',
+            )}
+          >
+            {displayValue}
+          </span>
+        </div>
+
+        {hasPresets ? (
+          <div
+            aria-describedby={messageId}
+            aria-labelledby={labelId}
+            className={cn(
+              'p-date-range-picker__presets',
+              presetColumns !== 'auto' && 'p-date-range-picker__presets--fixed',
+            )}
+            role="group"
+          >
+            {presets.map((preset) => {
+              const presetRange = resolvePresetRange(preset);
+              const isActive = isSameRange(presetRange, selectedValue);
+
+              return (
+                <button
+                  key={preset.label}
+                  type="button"
+                  className={cn('p-date-range-picker__preset', isActive && 'p-date-range-picker__preset--active')}
+                  disabled={disabled}
+                  aria-pressed={isActive}
+                  onClick={() => handlePresetClick(preset)}
+                >
+                  {preset.label}
+                </button>
+              );
+            })}
+            {shouldRenderCustom ? (
+              <button
+                type="button"
+                className={cn(
+                  'p-date-range-picker__preset',
+                  isCustomActive && 'p-date-range-picker__preset--active',
+                )}
+                disabled={disabled}
+                aria-controls={panelId}
+                aria-expanded={isOpen}
+                aria-pressed={isCustomActive}
+                onClick={(event) => (isOpen ? closeCalendar(true) : openCalendar(event.currentTarget))}
+              >
+                {customLabel}
+              </button>
+            ) : null}
+          </div>
+        ) : (
+          <button
+            type="button"
+            className={cn(
+              'p-date-range-picker__trigger',
+              !hasCompleteRange && 'p-date-range-picker__trigger--empty',
+            )}
+            disabled={disabled}
+            aria-controls={panelId}
+            aria-describedby={messageId}
+            aria-expanded={isOpen}
+            aria-haspopup="dialog"
+            aria-labelledby={labelId}
+            onClick={(event) => (isOpen ? closeCalendar(true) : openCalendar(event.currentTarget))}
+          >
+            <span>{displayValue}</span>
+            <span className="p-date-range-picker__trigger-icon">
+              <CalendarIcon />
+            </span>
+          </button>
+        )}
+
+        <input type="hidden" name={nameStart} value={selectedValue?.start ?? ''} required={required} />
+        <input type="hidden" name={nameEnd} value={selectedValue?.end ?? ''} required={required} />
+
+        {isOpen && (
+          <div
+            id={panelId}
+            className="p-date-range-picker__panel"
+            role="dialog"
+            aria-labelledby={`${panelId}-title`}
+            onKeyDown={(event) => {
+              if (event.key === 'Escape') {
+                closeCalendar();
+              }
+            }}
+          >
+            <div className="p-date-range-picker__calendar-header">
+              <button
+                type="button"
+                className="p-date-range-picker__nav"
+                aria-label="Previous month"
+                onClick={() => setVisibleMonth((date) => addMonths(date, -1))}
+              >
+                <ChevronLeftIcon />
+              </button>
+              <div id={`${panelId}-title`} className="p-date-range-picker__month">
+                {getMonthLabel(visibleMonth, locale)}
+              </div>
+              <button
+                type="button"
+                className="p-date-range-picker__nav"
+                aria-label="Next month"
+                onClick={() => setVisibleMonth((date) => addMonths(date, 1))}
+              >
+                <ChevronRightIcon />
+              </button>
+            </div>
+
+            <div className="p-date-range-picker__weekdays" aria-hidden="true">
+              {weekdayLabels.map((weekday) => (
+                <span key={weekday}>{weekday}</span>
+              ))}
+            </div>
+
+            <div className="p-date-range-picker__grid" role="grid" aria-labelledby={`${panelId}-title`}>
+              {calendarDays.map((date) => {
+                const isoDate = toIsoDate(date);
+                const isOutsideMonth = date.getMonth() !== visibleMonth.getMonth();
+                const isRangeStart = isSameDay(date, startDate);
+                const isRangeEnd = isSameDay(date, endDate);
+                const isRangeMiddle = isInRange(date, startDate, endDate);
+                const isToday = isSameDay(date, today);
+                const isDisabled = isBeforeDate(date, minDate) || isAfterDate(date, maxDate);
+
+                return (
+                  <button
+                    key={isoDate}
+                    ref={(node) => {
+                      dayRefs.current[isoDate] = node as unknown as FocusableElement | null;
+                    }}
+                    type="button"
+                    role="gridcell"
+                    data-date={isoDate}
+                    className={cn(
+                      'p-date-range-picker__day',
+                      isOutsideMonth && 'p-date-range-picker__day--outside',
+                      isToday && 'p-date-range-picker__day--today',
+                      isRangeMiddle && 'p-date-range-picker__day--in-range',
+                      (isRangeStart || isRangeEnd) && 'p-date-range-picker__day--selected',
+                    )}
+                    disabled={isDisabled}
+                    aria-label={getDayLabel(date, locale)}
+                    aria-selected={isRangeStart || isRangeEnd}
+                    tabIndex={isSameDay(date, focusedDate) ? 0 : -1}
+                    onClick={() => handleDayClick(date)}
+                    onKeyDown={handleDayKeyDown(date)}
+                  >
+                    {date.getDate()}
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+        )}
+
+        {isError && errorMessage ? (
+          <p id={errorId} role="alert" className="p-date-range-picker__message p-date-range-picker__message--error">
+            {errorMessage}
+          </p>
+        ) : null}
+
+        {!isError && helperText ? (
+          <p id={helperId} className="p-date-range-picker__message">
+            {helperText}
+          </p>
+        ) : null}
+      </div>
+    );
+  },
+);
+
+PDateRangePicker.displayName = 'PDateRangePicker';
+
+export const PDateRangePickerPresets = {
+  thisWeek: {
+    label: 'This week',
+    value: () => {
+      const today = getToday();
+      const weekStart = addDays(today, -today.getDay());
+
+      return {
+        start: toIsoDate(weekStart),
+        end: toIsoDate(addDays(weekStart, 6)),
+      };
+    },
+  },
+  last7Days: {
+    label: 'Last 7 days',
+    value: () => {
+      const today = getToday();
+      return {
+        start: toIsoDate(addDays(today, -6)),
+        end: toIsoDate(today),
+      };
+    },
+  },
+  last14Days: {
+    label: 'Last 14 days',
+    value: () => {
+      const today = getToday();
+      return {
+        start: toIsoDate(addDays(today, -13)),
+        end: toIsoDate(today),
+      };
+    },
+  },
+  last30Days: {
+    label: 'Last 30 days',
+    value: () => {
+      const today = getToday();
+      return {
+        start: toIsoDate(addDays(today, -29)),
+        end: toIsoDate(today),
+      };
+    },
+  },
+  thisMonth: {
+    label: 'This month',
+    value: () => {
+      const today = getToday();
+      const start = startOfMonth(today);
+      const end = endOfMonth(today);
+
+      return {
+        start: toIsoDate(start),
+        end: toIsoDate(end),
+      };
+    },
+  },
+  lastMonth: {
+    label: 'Last month',
+    value: () => {
+      const today = getToday();
+      const lastMonth = addMonths(today, -1);
+
+      return {
+        start: toIsoDate(startOfMonth(lastMonth)),
+        end: toIsoDate(endOfMonth(lastMonth)),
+      };
+    },
+  },
+  monthToDate: {
+    label: 'Month to date',
+    value: () => {
+      const today = getToday();
+      const start = startOfMonth(today);
+
+      return {
+        start: toIsoDate(start),
+        end: toIsoDate(today),
+      };
+    },
+  },
+  yearToDate: {
+    label: 'Year to date',
+    value: () => {
+      const today = getToday();
+
+      return {
+        start: toIsoDate(new Date(today.getFullYear(), 0, 1)),
+        end: toIsoDate(today),
+      };
+    },
+  },
+} satisfies Record<string, PDateRangePickerPreset>;

--- a/src/components/PDateRangePicker/index.ts
+++ b/src/components/PDateRangePicker/index.ts
@@ -1,0 +1,10 @@
+export {
+  PDateRangePicker,
+  PDateRangePickerPresets,
+  type PDateRangePickerChangeSource,
+  type PDateRangePickerPreset,
+  type PDateRangePickerPresetColumns,
+  type PDateRangePickerProps,
+  type PDateRangePickerRef,
+  type PDateRangeValue,
+} from './PDateRangePicker';

--- a/src/components/PHighlight/PHighlight.css
+++ b/src/components/PHighlight/PHighlight.css
@@ -1,0 +1,58 @@
+.p-highlight {
+  --p-highlight-color: var(--p-color-action-primary);
+  --p-highlight-bg: var(--p-color-action-primary);
+  --p-highlight-text: var(--p-color-text-inverse);
+
+  display: inline;
+  background: transparent;
+  color: var(--p-highlight-color);
+  font: inherit;
+  letter-spacing: inherit;
+  line-height: inherit;
+  text-transform: inherit;
+}
+
+.p-highlight--background {
+  margin-inline: -0.02em;
+  padding-inline: 0.08em;
+  background: var(--p-highlight-bg);
+  box-decoration-break: clone;
+  color: var(--p-highlight-text);
+  -webkit-box-decoration-break: clone;
+}
+
+.p-highlight--primary {
+  --p-highlight-color: var(--p-color-action-primary);
+  --p-highlight-bg: var(--p-color-action-primary);
+  --p-highlight-text: var(--p-color-text-inverse);
+}
+
+.p-highlight--danger {
+  --p-highlight-color: var(--p-color-danger);
+  --p-highlight-bg: var(--p-color-danger);
+  --p-highlight-text: var(--p-color-text-inverse);
+}
+
+.p-highlight--warning {
+  --p-highlight-color: var(--p-color-warning);
+  --p-highlight-bg: var(--p-color-warning);
+  --p-highlight-text: var(--p-color-neutral-950);
+}
+
+.p-highlight--success {
+  --p-highlight-color: var(--p-color-success);
+  --p-highlight-bg: var(--p-color-success);
+  --p-highlight-text: var(--p-color-text-inverse);
+}
+
+.p-highlight--info {
+  --p-highlight-color: var(--p-color-info);
+  --p-highlight-bg: var(--p-color-info);
+  --p-highlight-text: var(--p-color-text-inverse);
+}
+
+.p-highlight--neutral {
+  --p-highlight-color: var(--p-color-text);
+  --p-highlight-bg: var(--p-color-surface-inverse);
+  --p-highlight-text: var(--p-color-text-inverse);
+}

--- a/src/components/PHighlight/PHighlight.stories.tsx
+++ b/src/components/PHighlight/PHighlight.stories.tsx
@@ -1,0 +1,112 @@
+import { type Meta, type StoryObj } from '@storybook/react';
+import { PTypography } from '../PTypography';
+import { PHighlight } from '.';
+
+const meta: Meta<typeof PHighlight> = {
+  title: 'Components/PHighlight',
+  component: PHighlight,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered',
+  },
+  args: {
+    children: 'SIMPLE',
+    variant: 'primary',
+  },
+  argTypes: {
+    as: {
+      description: 'Rendered element. Defaults to span for inline typography emphasis.',
+    },
+    appearance: {
+      control: 'select',
+      options: ['text', 'background'],
+      description: 'Text-only emphasis by default, or a filled highlight background.',
+    },
+    variant: {
+      control: 'select',
+      options: ['primary', 'danger', 'warning', 'success', 'info', 'neutral'],
+      description: 'Semantic highlight treatment.',
+    },
+    color: {
+      control: 'color',
+      description: 'Custom highlight color. Text color by default, background color in background mode.',
+    },
+    textColor: {
+      control: 'color',
+      description: 'Custom foreground color for background mode.',
+    },
+  },
+};
+
+type Story = StoryObj<typeof PHighlight>;
+
+export const Default: Story = {
+  name: 'Default',
+};
+
+export const HeroUseCase: Story = {
+  name: 'Hero Use Case',
+  render: () => (
+    <div style={{ textAlign: 'center' }}>
+      <PTypography variant="heading-xl">KEEPING</PTypography>
+      <PTypography variant="heading-xl">THINGS</PTypography>
+      <PTypography variant="heading-xl">
+        <PHighlight>SIMPLE</PHighlight>
+      </PTypography>
+      <PTypography variant="heading-xl">SINCE</PTypography>
+      <PTypography variant="heading-xl">2017</PTypography>
+    </div>
+  ),
+};
+
+export const Variants: Story = {
+  name: 'Variants',
+  render: () => (
+    <div style={{ display: 'flex', flexWrap: 'wrap', gap: '1rem' }}>
+      <PHighlight>Primary</PHighlight>
+      <PHighlight variant="danger">Danger</PHighlight>
+      <PHighlight variant="warning">Warning</PHighlight>
+      <PHighlight variant="success">Success</PHighlight>
+      <PHighlight variant="info">Info</PHighlight>
+      <PHighlight variant="neutral">Neutral</PHighlight>
+    </div>
+  ),
+};
+
+export const CustomColor: Story = {
+  name: 'Custom Color',
+  args: {
+    color: '#111111',
+    children: 'CUSTOM',
+  },
+};
+
+export const Background: Story = {
+  name: 'Background',
+  args: {
+    appearance: 'background',
+    children: 'SIMPLE',
+  },
+};
+
+export const CustomBackground: Story = {
+  name: 'Custom Background',
+  args: {
+    appearance: 'background',
+    color: '#111111',
+    textColor: '#ffffff',
+    children: 'CUSTOM',
+  },
+};
+
+export const InlineCopy: Story = {
+  name: 'Inline Copy',
+  render: () => (
+    <PTypography variant="body">
+      Keep the content scannable and use <PHighlight variant="warning">one clear emphasis</PHighlight>{' '}
+      per sentence.
+    </PTypography>
+  ),
+};
+
+export default meta;

--- a/src/components/PHighlight/PHighlight.tsx
+++ b/src/components/PHighlight/PHighlight.tsx
@@ -1,0 +1,74 @@
+import {
+  forwardRef,
+  type CSSProperties,
+  type ElementType,
+  type HTMLAttributes,
+  type ReactNode,
+} from 'react';
+import cn from '../../utils/cn';
+import './PHighlight.css';
+
+export type PHighlightVariant = 'primary' | 'danger' | 'warning' | 'success' | 'info' | 'neutral';
+export type PHighlightAppearance = 'text' | 'background';
+export type PHighlightRef = HTMLElement;
+
+export type PHighlightProps = {
+  as?: ElementType;
+  variant?: PHighlightVariant;
+  /** Controls whether the highlight is text-only or a filled background. */
+  appearance?: PHighlightAppearance;
+  /** Custom highlight color. Text color by default, background color for `appearance="background"`. */
+  color?: CSSProperties['color'];
+  /** Custom foreground color for `appearance="background"`. */
+  textColor?: CSSProperties['color'];
+  children: ReactNode;
+  className?: string;
+  style?: CSSProperties;
+} & Omit<HTMLAttributes<HTMLElement>, 'children' | 'className' | 'color' | 'style'>;
+
+type PHighlightStyle = CSSProperties & {
+  '--p-highlight-color'?: CSSProperties['color'];
+  '--p-highlight-bg'?: CSSProperties['backgroundColor'];
+  '--p-highlight-text'?: CSSProperties['color'];
+};
+
+export const PHighlight = forwardRef<PHighlightRef, PHighlightProps>(
+  (
+    {
+      as: Element = 'span',
+      variant = 'primary',
+      appearance = 'text',
+      color,
+      textColor,
+      children,
+      className,
+      style,
+      ...props
+    },
+    ref,
+  ) => {
+    const highlightStyle: PHighlightStyle = {
+      ...style,
+      ...(color ? { '--p-highlight-color': color, '--p-highlight-bg': color } : {}),
+      ...(textColor ? { '--p-highlight-text': textColor } : {}),
+    };
+
+    return (
+      <Element
+        {...props}
+        ref={ref}
+        className={cn(
+          'p-highlight',
+          `p-highlight--${variant}`,
+          appearance === 'background' && 'p-highlight--background',
+          className,
+        )}
+        style={highlightStyle}
+      >
+        {children}
+      </Element>
+    );
+  },
+);
+
+PHighlight.displayName = 'PHighlight';

--- a/src/components/PHighlight/index.ts
+++ b/src/components/PHighlight/index.ts
@@ -1,0 +1,7 @@
+export {
+  PHighlight,
+  type PHighlightAppearance,
+  type PHighlightProps,
+  type PHighlightRef,
+  type PHighlightVariant,
+} from './PHighlight';

--- a/src/components/PHorizontalSlider/PHorizontalSlider.css
+++ b/src/components/PHorizontalSlider/PHorizontalSlider.css
@@ -1,0 +1,118 @@
+.p-horizontal-slider {
+  --p-horizontal-slider-gap: var(--p-space-4);
+  --p-horizontal-slider-padding-block: var(--p-space-6);
+  --p-horizontal-slider-padding-inline-end: var(--p-space-8);
+  --p-horizontal-slider-padding-inline-start: max(
+    var(--p-space-6),
+    calc((100vw - 40rem) / 2 + var(--p-space-2))
+  );
+  --p-horizontal-slider-scroll-padding-inline-start: max(
+    var(--p-space-6),
+    calc((100vw - 40rem) / 2)
+  );
+
+  position: relative;
+  width: 100%;
+}
+
+.p-horizontal-slider__scroller {
+  overflow-x: auto;
+  overscroll-behavior-x: contain;
+  padding-block: var(--p-horizontal-slider-padding-block);
+  padding-inline: var(--p-horizontal-slider-padding-inline-start)
+    var(--p-horizontal-slider-padding-inline-end);
+  scroll-padding-inline-start: var(--p-horizontal-slider-scroll-padding-inline-start);
+  scroll-snap-type: x mandatory;
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+}
+
+.p-horizontal-slider__scroller::-webkit-scrollbar {
+  display: none;
+}
+
+.p-horizontal-slider__scroller:focus {
+  outline: none;
+}
+
+.p-horizontal-slider__scroller:focus-visible {
+  box-shadow: inset 0 0 0 var(--p-focus-ring-width) var(--p-focus-ring-color);
+  outline: var(--p-focus-outline-width) solid transparent;
+  outline-offset: calc(var(--p-focus-ring-offset) * -1);
+}
+
+.p-horizontal-slider__list {
+  display: inline-flex;
+  min-width: 100%;
+  flex-direction: row;
+  gap: var(--p-horizontal-slider-gap);
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.p-horizontal-slider__item {
+  flex: 0 0 auto;
+  scroll-snap-align: start;
+}
+
+.p-horizontal-slider--no-snap .p-horizontal-slider__scroller {
+  scroll-snap-type: none;
+}
+
+.p-horizontal-slider--no-snap .p-horizontal-slider__item {
+  scroll-snap-align: none;
+}
+
+@media (min-width: 48rem) {
+  .p-horizontal-slider {
+    --p-horizontal-slider-padding-inline-start: max(
+      var(--p-space-8),
+      calc((100vw - 48rem) / 2 + var(--p-space-4))
+    );
+    --p-horizontal-slider-scroll-padding-inline-start: max(
+      var(--p-space-8),
+      calc((100vw - 48rem) / 2)
+    );
+  }
+}
+
+@media (min-width: 64rem) {
+  .p-horizontal-slider {
+    --p-horizontal-slider-padding-block: var(--p-space-10);
+    --p-horizontal-slider-padding-inline-start: max(
+      var(--p-space-12),
+      calc((100vw - 64rem) / 2 + var(--p-space-8))
+    );
+    --p-horizontal-slider-scroll-padding-inline-start: max(
+      var(--p-space-12),
+      calc((100vw - 64rem) / 2)
+    );
+  }
+}
+
+@media (min-width: 80rem) {
+  .p-horizontal-slider {
+    --p-horizontal-slider-padding-inline-start: max(
+      var(--p-space-20),
+      calc((100vw - 80rem) / 2 + var(--p-space-16))
+    );
+    --p-horizontal-slider-scroll-padding-inline-start: max(
+      var(--p-space-20),
+      calc((100vw - 80rem) / 2)
+    );
+  }
+}
+
+@media (min-width: 96rem) {
+  .p-horizontal-slider {
+    --p-horizontal-slider-padding-inline-start: max(
+      var(--p-space-24),
+      calc((100vw - 96rem) / 2 + var(--p-space-20))
+    );
+    --p-horizontal-slider-scroll-padding-inline-start: max(
+      var(--p-space-24),
+      calc((100vw - 96rem) / 2)
+    );
+  }
+}

--- a/src/components/PHorizontalSlider/PHorizontalSlider.css
+++ b/src/components/PHorizontalSlider/PHorizontalSlider.css
@@ -1,5 +1,5 @@
 .p-horizontal-slider {
-  --p-horizontal-slider-gap: var(--p-space-4);
+  --p-horizontal-slider-gap: var(--p-space-3);
   --p-horizontal-slider-padding-block: var(--p-space-6);
   --p-horizontal-slider-padding-inline-end: var(--p-space-8);
   --p-horizontal-slider-padding-inline-start: max(

--- a/src/components/PHorizontalSlider/PHorizontalSlider.css
+++ b/src/components/PHorizontalSlider/PHorizontalSlider.css
@@ -1,5 +1,5 @@
 .p-horizontal-slider {
-  --p-horizontal-slider-gap: var(--p-space-3);
+  --p-horizontal-slider-gap: var(--p-space-2);
   --p-horizontal-slider-padding-block: var(--p-space-6);
   --p-horizontal-slider-padding-inline-end: var(--p-space-8);
   --p-horizontal-slider-padding-inline-start: max(

--- a/src/components/PHorizontalSlider/PHorizontalSlider.stories.tsx
+++ b/src/components/PHorizontalSlider/PHorizontalSlider.stories.tsx
@@ -2,34 +2,35 @@ import { type Meta, type StoryObj } from '@storybook/react';
 import { PHorizontalSlider } from '.';
 import { PCard } from '../PCard';
 
-const items = [
+type SliderStoryItem = {
+  title: string;
+  width: number;
+};
+
+const items: SliderStoryItem[] = [
   {
     title: 'Pipeline overview',
-    description: 'Scan open opportunities and handoff points.',
-    eyebrow: 'Sales',
+    width: 300,
   },
   {
     title: 'Risk review',
-    eyebrow: 'Control',
+    width: 300,
   },
   {
     title: 'Contract queue',
-    description: 'Track approvals across legal and finance.',
-    eyebrow: 'Legal',
+    width: 300,
   },
   {
     title: 'Account health',
-    description: 'Monitor renewal posture and support load.',
-    eyebrow: 'Success',
+    width: 300,
   },
   {
     title: 'Renewal forecast',
-    eyebrow: 'Finance',
+    width: 300,
   },
   {
     title: 'Support load',
-    description: 'Review request volume and current response risk.',
-    eyebrow: 'Service',
+    width: 300,
   },
 ];
 
@@ -43,13 +44,7 @@ const meta: Meta<typeof PHorizontalSlider> = {
   args: {
     ariaLabel: 'Featured content',
     children: items.map((item, index) => (
-      <PCard
-        key={item.title}
-        prefix={String(index + 1).padStart(2, '0')}
-        eyebrow={item.eyebrow}
-        title={item.title}
-        description={item.description}
-      />
+      <PCard key={item.title} prefix={String(index + 1).padStart(2, '0')} {...item} />
     )),
   },
   argTypes: {

--- a/src/components/PHorizontalSlider/PHorizontalSlider.stories.tsx
+++ b/src/components/PHorizontalSlider/PHorizontalSlider.stories.tsx
@@ -1,36 +1,37 @@
 import { type Meta, type StoryObj } from '@storybook/react';
 import { PHorizontalSlider } from '.';
-import { PTypography } from '../PTypography';
+import { PCard } from '../PCard';
 
 const items = [
-  'Pipeline overview',
-  'Risk review',
-  'Contract queue',
-  'Account health',
-  'Renewal forecast',
-  'Support load',
+  {
+    title: 'Pipeline overview',
+    description: 'Scan open opportunities and handoff points.',
+    eyebrow: 'Sales',
+  },
+  {
+    title: 'Risk review',
+    eyebrow: 'Control',
+  },
+  {
+    title: 'Contract queue',
+    description: 'Track approvals across legal and finance.',
+    eyebrow: 'Legal',
+  },
+  {
+    title: 'Account health',
+    description: 'Monitor renewal posture and support load.',
+    eyebrow: 'Success',
+  },
+  {
+    title: 'Renewal forecast',
+    eyebrow: 'Finance',
+  },
+  {
+    title: 'Support load',
+    description: 'Review request volume and current response risk.',
+    eyebrow: 'Service',
+  },
 ];
-
-function SliderCard({ index, title }: { index: number; title: string }) {
-  return (
-    <article
-      style={{
-        width: 260,
-        minHeight: 180,
-        border: '1px solid var(--p-color-border)',
-        background: 'var(--p-color-surface)',
-        padding: 'var(--p-space-4)',
-      }}
-    >
-      <PTypography variant="body-wide" style={{ color: 'var(--p-color-text-muted)' }}>
-        {String(index + 1).padStart(2, '0')}
-      </PTypography>
-      <div style={{ marginTop: 'var(--p-space-8)' }}>
-        <PTypography variant="heading">{title}</PTypography>
-      </div>
-    </article>
-  );
-}
 
 const meta: Meta<typeof PHorizontalSlider> = {
   title: 'Components/PHorizontalSlider',
@@ -42,7 +43,13 @@ const meta: Meta<typeof PHorizontalSlider> = {
   args: {
     ariaLabel: 'Featured content',
     children: items.map((item, index) => (
-      <SliderCard key={item} index={index} title={item} />
+      <PCard
+        key={item.title}
+        prefix={String(index + 1).padStart(2, '0')}
+        eyebrow={item.eyebrow}
+        title={item.title}
+        description={item.description}
+      />
     )),
   },
   argTypes: {

--- a/src/components/PHorizontalSlider/PHorizontalSlider.stories.tsx
+++ b/src/components/PHorizontalSlider/PHorizontalSlider.stories.tsx
@@ -1,0 +1,90 @@
+import { type Meta, type StoryObj } from '@storybook/react';
+import { PHorizontalSlider } from '.';
+import { PTypography } from '../PTypography';
+
+const items = [
+  'Pipeline overview',
+  'Risk review',
+  'Contract queue',
+  'Account health',
+  'Renewal forecast',
+  'Support load',
+];
+
+function SliderCard({ index, title }: { index: number; title: string }) {
+  return (
+    <article
+      style={{
+        width: 260,
+        minHeight: 180,
+        border: '1px solid var(--p-color-border)',
+        background: 'var(--p-color-surface)',
+        padding: 'var(--p-space-4)',
+      }}
+    >
+      <PTypography variant="body-wide" style={{ color: 'var(--p-color-text-muted)' }}>
+        {String(index + 1).padStart(2, '0')}
+      </PTypography>
+      <div style={{ marginTop: 'var(--p-space-8)' }}>
+        <PTypography variant="heading">{title}</PTypography>
+      </div>
+    </article>
+  );
+}
+
+const meta: Meta<typeof PHorizontalSlider> = {
+  title: 'Components/PHorizontalSlider',
+  component: PHorizontalSlider,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'fullscreen',
+  },
+  args: {
+    ariaLabel: 'Featured content',
+    children: items.map((item, index) => (
+      <SliderCard key={item} index={index} title={item} />
+    )),
+  },
+  argTypes: {
+    ariaLabel: {
+      description: 'Accessible label for the keyboard-focusable scroll region.',
+    },
+    gap: {
+      description: 'Gap between slider items. Accepts any CSS gap value.',
+    },
+    snap: {
+      description: 'Enables or disables horizontal snap alignment.',
+    },
+    scrollerClassName: {
+      description: 'Applied to the scrollable region.',
+    },
+    listClassName: {
+      description: 'Applied to the inner list.',
+    },
+    itemClassName: {
+      description: 'Applied to each generated list item.',
+    },
+  },
+};
+
+type Story = StoryObj<typeof PHorizontalSlider>;
+
+export const Default: Story = {
+  name: 'Default',
+};
+
+export const Compact: Story = {
+  name: 'Compact',
+  args: {
+    gap: 'var(--p-space-2)',
+  },
+};
+
+export const FreeScroll: Story = {
+  name: 'Free Scroll',
+  args: {
+    snap: false,
+  },
+};
+
+export default meta;

--- a/src/components/PHorizontalSlider/PHorizontalSlider.tsx
+++ b/src/components/PHorizontalSlider/PHorizontalSlider.tsx
@@ -1,0 +1,77 @@
+import {
+  Children,
+  forwardRef,
+  type CSSProperties,
+  type HTMLAttributes,
+  type ReactNode,
+} from 'react';
+import cn from '../../utils/cn';
+import './PHorizontalSlider.css';
+
+export type PHorizontalSliderRef = HTMLDivElement;
+
+export type PHorizontalSliderProps = {
+  children: ReactNode;
+  /** Accessible label for the keyboard-focusable scroll region. */
+  ariaLabel?: string;
+  /** Gap between slider items. Accepts any CSS gap value. */
+  gap?: CSSProperties['gap'];
+  /** Disables horizontal snap alignment when free scrolling is preferred. */
+  snap?: boolean;
+  scrollerClassName?: string;
+  listClassName?: string;
+  itemClassName?: string;
+} & Omit<HTMLAttributes<HTMLDivElement>, 'children' | 'className'> & {
+    className?: string;
+  };
+
+type SliderStyle = CSSProperties & {
+  '--p-horizontal-slider-gap'?: CSSProperties['gap'];
+};
+
+export const PHorizontalSlider = forwardRef<PHorizontalSliderRef, PHorizontalSliderProps>(
+  (
+    {
+      children,
+      ariaLabel = 'Horizontal content',
+      gap,
+      snap = true,
+      className,
+      scrollerClassName,
+      listClassName,
+      itemClassName,
+      style,
+      ...props
+    },
+    ref,
+  ) => {
+    const sliderStyle: SliderStyle = {
+      ...style,
+      ...(gap ? { '--p-horizontal-slider-gap': gap } : {}),
+    };
+
+    return (
+      <div
+        {...props}
+        ref={ref}
+        className={cn('p-horizontal-slider', !snap && 'p-horizontal-slider--no-snap', className)}
+        style={sliderStyle}
+      >
+        <div
+          aria-label={ariaLabel}
+          className={cn('p-horizontal-slider__scroller', scrollerClassName)}
+          role="region"
+          tabIndex={0}
+        >
+          <ul className={cn('p-horizontal-slider__list', listClassName)}>
+            {Children.map(children, (child) => (
+              <li className={cn('p-horizontal-slider__item', itemClassName)}>{child}</li>
+            ))}
+          </ul>
+        </div>
+      </div>
+    );
+  },
+);
+
+PHorizontalSlider.displayName = 'PHorizontalSlider';

--- a/src/components/PHorizontalSlider/index.ts
+++ b/src/components/PHorizontalSlider/index.ts
@@ -1,0 +1,5 @@
+export {
+  PHorizontalSlider,
+  type PHorizontalSliderProps,
+  type PHorizontalSliderRef,
+} from './PHorizontalSlider';

--- a/src/components/PSectionHeader/PSectionHeader.stories.tsx
+++ b/src/components/PSectionHeader/PSectionHeader.stories.tsx
@@ -3,7 +3,7 @@ import { PSectionHeader } from '.';
 import { P_COLORS } from '../../constants';
 
 const meta: Meta<typeof PSectionHeader> = {
-  title: 'PSectionHeader',
+  title: 'Components/PSectionHeader',
   component: PSectionHeader,
   parameters: {
     backgrounds: {

--- a/src/components/PTypography/PTypography.stories.tsx
+++ b/src/components/PTypography/PTypography.stories.tsx
@@ -3,7 +3,7 @@ import { PTypography } from '.';
 import { P_COLORS } from '../../constants';
 
 const meta: Meta<typeof PTypography> = {
-  title: 'PTypography',
+  title: 'Components/PTypography',
   component: PTypography,
   args: {
     className: 'text-white',

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,5 +1,6 @@
 export { Row, Stack } from './PContainers';
 export { PButton, type PButtonProps, type PButtonRef } from './PButton';
+export { PCard, type PCardProps, type PCardRef } from './PCard';
 export {
   PHorizontalSlider,
   type PHorizontalSliderProps,

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,6 +1,40 @@
 export { Row, Stack } from './PContainers';
+export {
+  PBadge,
+  type PBadgeAppearance,
+  type PBadgeProps,
+  type PBadgeRef,
+  type PBadgeSize,
+  type PBadgeVariant,
+} from './PBadge';
 export { PButton, type PButtonProps, type PButtonRef } from './PButton';
 export { PCard, type PCardProps, type PCardRef } from './PCard';
+export {
+  PDatePicker,
+  PDatePickerPresets,
+  type PDatePickerChangeSource,
+  type PDatePickerPreset,
+  type PDatePickerPresetColumns,
+  type PDatePickerProps,
+  type PDatePickerRef,
+} from './PDatePicker';
+export {
+  PDateRangePicker,
+  PDateRangePickerPresets,
+  type PDateRangePickerChangeSource,
+  type PDateRangePickerPreset,
+  type PDateRangePickerPresetColumns,
+  type PDateRangePickerProps,
+  type PDateRangePickerRef,
+  type PDateRangeValue,
+} from './PDateRangePicker';
+export {
+  PHighlight,
+  type PHighlightAppearance,
+  type PHighlightProps,
+  type PHighlightRef,
+  type PHighlightVariant,
+} from './PHighlight';
 export {
   PHorizontalSlider,
   type PHorizontalSliderProps,

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,4 +1,5 @@
 export { Row, Stack } from './PContainers';
+export { PButton, type PButtonProps, type PButtonRef } from './PButton';
 export { PTypography, type PTypographyProps } from './PTypography';
 export { PSectionHeader } from './PSectionHeader';
 export { PTextInput, type PTextInputProps } from './PTextInput';

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,5 +1,10 @@
 export { Row, Stack } from './PContainers';
 export { PButton, type PButtonProps, type PButtonRef } from './PButton';
+export {
+  PHorizontalSlider,
+  type PHorizontalSliderProps,
+  type PHorizontalSliderRef,
+} from './PHorizontalSlider';
 export { PTypography, type PTypographyProps } from './PTypography';
 export { PSectionHeader } from './PSectionHeader';
 export { PTextInput, type PTextInputProps } from './PTextInput';

--- a/tests/ui/storybook-smoke.spec.ts
+++ b/tests/ui/storybook-smoke.spec.ts
@@ -114,6 +114,17 @@ test.describe('Storybook smoke tests', () => {
     expect(metrics.scrollWidth).toBeGreaterThan(metrics.clientWidth);
     await expect(page.getByRole('listitem')).toHaveCount(6);
   });
+
+  test('renders cards with metadata, description, and interactive semantics', async ({ page }) => {
+    await gotoStory(page, 'components-pcard--default');
+    await expect(page.getByText('01')).toBeVisible();
+    await expect(page.getByText('Operations')).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Pipeline overview' })).toBeVisible();
+    await expect(page.getByText('A compact summary card for scanning enterprise workflows.')).toBeVisible();
+
+    await gotoStory(page, 'components-pcard--interactive');
+    await expect(page.getByRole('link', { name: 'Open account summary' })).toBeVisible();
+  });
 });
 
 test.describe('Storybook accessibility checks', () => {
@@ -125,6 +136,8 @@ test.describe('Storybook accessibility checks', () => {
     'components-pbutton--loading',
     'components-pbutton--active',
     'components-pbutton--mobile',
+    'components-pcard--default',
+    'components-pcard--interactive',
     'components-phorizontalslider--default',
     'components-ptextinput--default',
     'components-ptextinput--with-error',

--- a/tests/ui/storybook-smoke.spec.ts
+++ b/tests/ui/storybook-smoke.spec.ts
@@ -96,6 +96,24 @@ test.describe('Storybook smoke tests', () => {
     expect(box?.width).toBeLessThanOrEqual(320);
     expect(box?.height).toBeGreaterThanOrEqual(44);
   });
+
+  test('renders a keyboard-focusable horizontal slider with overflow content', async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await gotoStory(page, 'components-phorizontalslider--default');
+
+    const scroller = page.getByRole('region', { name: 'Featured content' });
+    await expect(scroller).toBeVisible();
+    await scroller.focus();
+    await expect(scroller).toBeFocused();
+
+    const metrics = await scroller.evaluate((element) => ({
+      clientWidth: element.clientWidth,
+      scrollWidth: element.scrollWidth,
+    }));
+
+    expect(metrics.scrollWidth).toBeGreaterThan(metrics.clientWidth);
+    await expect(page.getByRole('listitem')).toHaveCount(6);
+  });
 });
 
 test.describe('Storybook accessibility checks', () => {
@@ -107,6 +125,7 @@ test.describe('Storybook accessibility checks', () => {
     'components-pbutton--loading',
     'components-pbutton--active',
     'components-pbutton--mobile',
+    'components-phorizontalslider--default',
     'components-ptextinput--default',
     'components-ptextinput--with-error',
     'components-ptextarea--default',

--- a/tests/ui/storybook-smoke.spec.ts
+++ b/tests/ui/storybook-smoke.spec.ts
@@ -17,6 +17,19 @@ async function expectNoA11yViolations(page: Page) {
 }
 
 test.describe('Storybook smoke tests', () => {
+  test('renders button actions and link semantics', async ({ page }) => {
+    await gotoStory(page, 'components-pbutton--primary');
+    await expect(page.getByRole('button', { name: 'Button' })).toBeVisible();
+
+    await gotoStory(page, 'components-pbutton--loading');
+    const loadingButton = page.getByRole('button', { name: 'Saving' });
+    await expect(loadingButton).toBeDisabled();
+    await expect(loadingButton).toHaveAttribute('aria-busy', 'true');
+
+    await gotoStory(page, 'components-pbutton--link');
+    await expect(page.getByRole('link', { name: 'Open details' })).toBeVisible();
+  });
+
   test('renders the critical typography stories', async ({ page }) => {
     await gotoStory(page, 'ptypography--body-wide');
     await expect(page.getByText('AVANT GARDE')).toBeVisible();
@@ -70,6 +83,10 @@ test.describe('Storybook smoke tests', () => {
 test.describe('Storybook accessibility checks', () => {
   for (const storyId of [
     'ptypography--body-wide',
+    'components-pbutton--primary',
+    'components-pbutton--secondary',
+    'components-pbutton--danger',
+    'components-pbutton--loading',
     'components-ptextinput--default',
     'components-ptextinput--with-error',
     'components-ptextarea--default',

--- a/tests/ui/storybook-smoke.spec.ts
+++ b/tests/ui/storybook-smoke.spec.ts
@@ -3,6 +3,19 @@ import { expect, type Page, test } from '@playwright/test';
 
 const storyUrl = (id: string) => `/iframe.html?id=${id}&viewMode=story`;
 
+function getCurrentMonthRangeLabel() {
+  const today = new Date();
+  const start = new Date(today.getFullYear(), today.getMonth(), 1);
+  const end = new Date(today.getFullYear(), today.getMonth() + 1, 0);
+  const formatter = new Intl.DateTimeFormat('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  });
+
+  return `${formatter.format(start)} - ${formatter.format(end)}`;
+}
+
 async function gotoStory(page: Page, id: string) {
   await page.goto(storyUrl(id));
   await expect(page.locator('#storybook-root')).toBeVisible();
@@ -14,6 +27,20 @@ async function gotoStory(page: Page, id: string) {
 async function expectNoA11yViolations(page: Page) {
   const results = await new AxeBuilder({ page }).include('#storybook-root').analyze();
   expect(results.violations).toEqual([]);
+}
+
+async function expectGridColumnCount(page: Page, selector: string, count: number) {
+  const columns = await page
+    .locator(selector)
+    .first()
+    .evaluate((element) => getComputedStyle(element).gridTemplateColumns.split(' ').length);
+
+  expect(columns).toBe(count);
+}
+
+async function expectElementWidthAtLeast(page: Page, selector: string, width: number) {
+  const box = await page.locator(selector).first().boundingBox();
+  expect(box?.width).toBeGreaterThanOrEqual(width);
 }
 
 test.describe('Storybook smoke tests', () => {
@@ -36,19 +63,36 @@ test.describe('Storybook smoke tests', () => {
     await expect(page.getByRole('link', { name: 'Open details' })).toBeVisible();
   });
 
+  test('renders badge variants, icons, and truncation', async ({ page }) => {
+    await gotoStory(page, 'components-pbadge--default');
+    await expect(page.getByText('Active')).toBeVisible();
+
+    const badge = page.locator('.p-badge').first();
+    await expect(badge).toHaveCSS('display', 'inline-flex');
+
+    await gotoStory(page, 'components-pbadge--with-icon');
+    await expect(page.getByText('Online')).toBeVisible();
+    await expect(page.locator('.p-badge__icon')).toHaveCount(1);
+
+    await gotoStory(page, 'components-pbadge--truncated');
+    const truncatedBadge = page.locator('.p-badge').first();
+    const truncatedBox = await truncatedBadge.boundingBox();
+    expect(truncatedBox?.width).toBeLessThanOrEqual(120);
+  });
+
   test('renders the critical typography stories', async ({ page }) => {
-    await gotoStory(page, 'ptypography--body-wide');
+    await gotoStory(page, 'components-ptypography--body-wide');
     await expect(page.getByText('AVANT GARDE')).toBeVisible();
 
-    await gotoStory(page, 'ptypography--heading');
+    await gotoStory(page, 'components-ptypography--heading');
     await expect(page.getByText('This is a heading')).toBeVisible();
 
-    await gotoStory(page, 'ptypography--serif');
+    await gotoStory(page, 'components-ptypography--serif');
     await expect(page.getByText(/Lorem ipsum dolor sit amet/).first()).toBeVisible();
   });
 
   test('keeps the Serif variant on the enterprise serif contract', async ({ page }) => {
-    await gotoStory(page, 'ptypography--serif');
+    await gotoStory(page, 'components-ptypography--serif');
 
     const serifText = page.getByText(/Lorem ipsum dolor sit amet/).first();
     await expect(serifText).toBeVisible();
@@ -65,6 +109,88 @@ test.describe('Storybook smoke tests', () => {
 
     await gotoStory(page, 'components-ptextinput--disabled');
     await expect(page.getByLabel('Label')).toBeDisabled();
+  });
+
+  test('renders date picker standard and preset flows', async ({ page }) => {
+    await gotoStory(page, 'components-pdatepicker--standard');
+    await expect(page.getByLabel('Due date')).toBeVisible();
+    await expectElementWidthAtLeast(page, '.p-date-picker', 350);
+    await page.getByLabel('Due date').click();
+    await expect(page.getByRole('dialog', { name: 'May 2026' })).toBeVisible();
+    const selectedDueDate = page.getByRole('gridcell', { name: 'Sunday, May 10, 2026' });
+    await expect(selectedDueDate).toHaveAttribute('aria-selected', 'true');
+    await expect(selectedDueDate).toBeFocused();
+    await page.keyboard.press('ArrowRight');
+    await expect(page.getByRole('gridcell', { name: 'Monday, May 11, 2026' })).toBeFocused();
+
+    await gotoStory(page, 'components-pdatepicker--with-presets');
+    await expect(page.getByRole('group', { name: 'Report date' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Today' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Yesterday' })).toBeVisible();
+    await expectGridColumnCount(page, '.p-date-picker__presets', 3);
+    await expectElementWidthAtLeast(page, '.p-date-picker', 350);
+    await page.getByRole('button', { name: 'Custom' }).click();
+    await expect(page.getByRole('dialog')).toBeVisible();
+    await page.getByRole('gridcell', { name: 'Friday, May 15, 2026' }).click();
+    await expect(page.getByRole('button', { name: 'Custom' })).toBeVisible();
+    await expect(page.locator('.p-date-picker__label-value')).toHaveText('May 15, 2026');
+
+    await gotoStory(page, 'components-pdatepicker--sample-with-other-fields');
+    const ownerBefore = await page.getByLabel('Owner').boundingBox();
+    await page.getByRole('button', { name: 'Custom' }).click();
+    await expect(page.getByRole('dialog')).toBeVisible();
+    const ownerAfter = await page.getByLabel('Owner').boundingBox();
+    expect(ownerAfter?.y).toBeGreaterThan(ownerBefore?.y ?? 0);
+
+    await gotoStory(page, 'components-pdatepicker--alternate-presets');
+    await expect(page.getByRole('button', { name: 'Yesterday' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Tomorrow' })).toBeVisible();
+
+    await gotoStory(page, 'components-pdatepicker--presets-only');
+    await expect(page.getByRole('button', { name: 'End of month' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Custom' })).toHaveCount(0);
+  });
+
+  test('renders date range picker selection and presets', async ({ page }) => {
+    await gotoStory(page, 'components-pdaterangepicker--standard');
+    await expect(page.getByRole('button', { name: /Report range/ })).toBeVisible();
+    await expectElementWidthAtLeast(page, '.p-date-range-picker', 350);
+    await page.getByRole('button', { name: /Report range/ }).click();
+    await expect(page.getByRole('dialog', { name: 'May 2026' })).toBeVisible();
+    const rangeStart = page.getByRole('gridcell', { name: 'Friday, May 1, 2026' });
+    await expect(rangeStart).toHaveAttribute('aria-selected', 'true');
+    await expect(rangeStart).toBeFocused();
+    await page.keyboard.press('ArrowDown');
+    await expect(page.getByRole('gridcell', { name: 'Friday, May 8, 2026' })).toBeFocused();
+    await expect(page.getByRole('gridcell', { name: 'Sunday, May 10, 2026' })).toHaveAttribute(
+      'aria-selected',
+      'true',
+    );
+
+    await gotoStory(page, 'components-pdaterangepicker--empty');
+    await page.getByRole('button', { name: /Booking range/ }).click();
+    await page.getByRole('gridcell', { name: 'Monday, May 4, 2026' }).click();
+    await page.getByRole('gridcell', { name: 'Friday, May 15, 2026' }).click();
+    await expect(page.locator('.p-date-range-picker__label-value')).toHaveText(
+      'May 4, 2026 - May 15, 2026',
+    );
+
+    await gotoStory(page, 'components-pdaterangepicker--with-presets');
+    await expect(page.getByRole('group', { name: /Analytics range/ })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Last 7 days' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'This month' })).toBeVisible();
+    await expectGridColumnCount(page, '.p-date-range-picker__presets', 3);
+    await expectElementWidthAtLeast(page, '.p-date-range-picker', 350);
+    await page.getByRole('button', { name: 'This month' }).click();
+    await expect(page.locator('.p-date-range-picker__label-value')).toHaveText(
+      getCurrentMonthRangeLabel(),
+    );
+    await page.getByRole('button', { name: 'Custom' }).click();
+    await expect(page.getByRole('dialog')).toBeVisible();
+
+    await gotoStory(page, 'components-pdaterangepicker--presets-only');
+    await expect(page.getByRole('button', { name: 'Year to date' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Custom' })).toHaveCount(0);
   });
 
   test('renders textarea states and announces errors', async ({ page }) => {
@@ -115,28 +241,92 @@ test.describe('Storybook smoke tests', () => {
     await expect(page.getByRole('listitem')).toHaveCount(6);
   });
 
+  test('renders highlight variants and custom colors', async ({ page }) => {
+    await gotoStory(page, 'components-phighlight--hero-use-case');
+    await expect(page.getByText('SIMPLE')).toBeVisible();
+
+    const heroHighlight = page.locator('.p-highlight').first();
+    await expect(heroHighlight).toHaveCSS('display', 'inline');
+    await expect(heroHighlight).toHaveCSS('background-color', 'rgba(0, 0, 0, 0)');
+
+    await gotoStory(page, 'components-phighlight--custom-color');
+    const customHighlight = page.locator('.p-highlight').first();
+    await expect(customHighlight).toHaveText('CUSTOM');
+    await expect(customHighlight).toHaveCSS('color', 'rgb(17, 17, 17)');
+
+    await gotoStory(page, 'components-phighlight--custom-background');
+    const customBackgroundHighlight = page.locator('.p-highlight').first();
+    await expect(customBackgroundHighlight).toHaveText('CUSTOM');
+    await expect(customBackgroundHighlight).toHaveCSS('background-color', 'rgb(17, 17, 17)');
+    await expect(customBackgroundHighlight).toHaveCSS('color', 'rgb(255, 255, 255)');
+  });
+
   test('renders cards with metadata, description, and interactive semantics', async ({ page }) => {
     await gotoStory(page, 'components-pcard--default');
     await expect(page.getByText('01')).toBeVisible();
-    await expect(page.getByText('Operations')).toBeVisible();
     await expect(page.getByRole('heading', { name: 'Pipeline overview' })).toBeVisible();
     await expect(page.getByText('A compact summary card for scanning enterprise workflows.')).toBeVisible();
 
+    await gotoStory(page, 'components-pcard--with-metadata');
+    await expect(page.getByText('Operations')).toBeVisible();
+
+    await gotoStory(page, 'components-pcard--without-description');
+    await expect(page.getByRole('heading', { name: 'Title-only card' })).toBeVisible();
+    await expect(page.getByText('A compact summary card for scanning enterprise workflows.')).toHaveCount(0);
+
+    await gotoStory(page, 'components-pcard--custom-width');
+    const customWidthCard = await page.locator('.p-card').boundingBox();
+    expect(customWidthCard?.width).toBeGreaterThanOrEqual(799);
+    expect(customWidthCard?.width).toBeLessThanOrEqual(801);
+
+    await gotoStory(page, 'components-pcard--custom-height');
+    const customHeightCard = await page.locator('.p-card').boundingBox();
+    expect(customHeightCard?.height).toBeGreaterThanOrEqual(239);
+    expect(customHeightCard?.height).toBeLessThanOrEqual(241);
+
+    await gotoStory(page, 'components-pcard--min-sizing');
+    const minSizingCard = await page.locator('.p-card').boundingBox();
+    expect(minSizingCard?.width).toBeGreaterThanOrEqual(360);
+    expect(minSizingCard?.height).toBeGreaterThanOrEqual(220);
+
     await gotoStory(page, 'components-pcard--interactive');
+    await expect(page.getByText('Operations')).toBeVisible();
     await expect(page.getByRole('link', { name: 'Open account summary' })).toBeVisible();
   });
 });
 
 test.describe('Storybook accessibility checks', () => {
   for (const storyId of [
-    'ptypography--body-wide',
+    'components-ptypography--body-wide',
+    'components-pbadge--default',
+    'components-pbadge--variants',
+    'components-pbadge--appearances',
+    'components-pbadge--with-icon',
     'components-pbutton--primary',
     'components-pbutton--secondary',
     'components-pbutton--danger',
     'components-pbutton--loading',
     'components-pbutton--active',
     'components-pbutton--mobile',
+    'components-phighlight--default',
+    'components-phighlight--hero-use-case',
+    'components-phighlight--custom-color',
+    'components-phighlight--custom-background',
+    'components-pdatepicker--standard',
+    'components-pdatepicker--with-presets',
+    'components-pdatepicker--many-presets',
+    'components-pdatepicker--presets-only',
+    'components-pdatepicker--with-error',
+    'components-pdaterangepicker--standard',
+    'components-pdaterangepicker--with-presets',
+    'components-pdaterangepicker--many-presets',
+    'components-pdaterangepicker--presets-only',
+    'components-pdaterangepicker--with-error',
     'components-pcard--default',
+    'components-pcard--without-description',
+    'components-pcard--custom-width',
+    'components-pcard--custom-height',
+    'components-pcard--min-sizing',
     'components-pcard--interactive',
     'components-phorizontalslider--default',
     'components-ptextinput--default',

--- a/tests/ui/storybook-smoke.spec.ts
+++ b/tests/ui/storybook-smoke.spec.ts
@@ -26,6 +26,12 @@ test.describe('Storybook smoke tests', () => {
     await expect(loadingButton).toBeDisabled();
     await expect(loadingButton).toHaveAttribute('aria-busy', 'true');
 
+    await gotoStory(page, 'components-pbutton--active');
+    await expect(page.getByRole('button', { name: 'Current view' })).toHaveAttribute(
+      'data-active',
+      'true',
+    );
+
     await gotoStory(page, 'components-pbutton--link');
     await expect(page.getByRole('link', { name: 'Open details' })).toBeVisible();
   });
@@ -78,6 +84,18 @@ test.describe('Storybook smoke tests', () => {
     const box = await input.boundingBox();
     expect(box?.width).toBeLessThanOrEqual(390);
   });
+
+  test('keeps mobile buttons within the viewport', async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await gotoStory(page, 'components-pbutton--mobile');
+
+    const button = page.getByRole('button', { name: 'Review and continue' });
+    await expect(button).toBeVisible();
+
+    const box = await button.boundingBox();
+    expect(box?.width).toBeLessThanOrEqual(320);
+    expect(box?.height).toBeGreaterThanOrEqual(44);
+  });
 });
 
 test.describe('Storybook accessibility checks', () => {
@@ -87,6 +105,8 @@ test.describe('Storybook accessibility checks', () => {
     'components-pbutton--secondary',
     'components-pbutton--danger',
     'components-pbutton--loading',
+    'components-pbutton--active',
+    'components-pbutton--mobile',
     'components-ptextinput--default',
     'components-ptextinput--with-error',
     'components-ptextarea--default',


### PR DESCRIPTION
## Summary
- Add badge, highlight, date picker, and date range picker components with Storybook coverage
- Extend cards with sizing/custom operations and refine horizontal slider spacing
- Add picker preset controls, preset-only mode, full-width form layout, keyboard calendar navigation, and locale-stable UI tests

## Validation
- npm run lint
- npm run build
- npm run test:ui

Chromatic was not run.