### PR TITLE
feat: add enterprise combobox and date picker refinements

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,6 +1,35 @@
 import type { StorybookConfig } from '@storybook/react-vite';
 import tailwindcss from '@tailwindcss/vite';
-import { mergeConfig } from 'vite';
+import { mergeConfig, type PluginOption } from 'vite';
+
+const STORYBOOK_EXCLUDED_PLUGIN_NAMES = new Set([
+  'p-copy-static-assets',
+  'vite:dts',
+  'vite-plugin-static-copy:build',
+  'vite-plugin-static-copy:serve',
+]);
+
+function removeLibraryBuildPlugins(plugins: PluginOption[] = []): PluginOption[] {
+  return plugins.flatMap((plugin) => {
+    if (!plugin) {
+      return [];
+    }
+
+    if (Array.isArray(plugin)) {
+      return removeLibraryBuildPlugins(plugin);
+    }
+
+    if (
+      typeof plugin === 'object' &&
+      'name' in plugin &&
+      STORYBOOK_EXCLUDED_PLUGIN_NAMES.has(plugin.name)
+    ) {
+      return [];
+    }
+
+    return [plugin];
+  });
+}
 
 const config: StorybookConfig = {
   stories: ['../src/**/*.mdx', '../src/**/*.stories.@(js|jsx|mjs|ts|tsx)'],
@@ -16,7 +45,10 @@ const config: StorybookConfig = {
     options: {},
   },
   viteFinal: async (config) => {
-    return mergeConfig(config, {
+    return mergeConfig({
+      ...config,
+      plugins: removeLibraryBuildPlugins(config.plugins),
+    }, {
       plugins: [tailwindcss()],
     });
   },

--- a/src/components/PCombobox/PCombobox.css
+++ b/src/components/PCombobox/PCombobox.css
@@ -1,0 +1,552 @@
+.p-combobox {
+    --p-combobox-bg: var(--p-control-bg);
+    --p-combobox-bg-hover: var(--p-control-bg-hover);
+    --p-combobox-bg-focus: var(--p-control-bg-focus);
+    --p-combobox-bg-readonly: var(--p-control-bg-readonly);
+    --p-combobox-panel-bg: var(--p-color-surface);
+    --p-combobox-text: var(--p-control-text);
+    --p-combobox-text-muted: var(--p-control-text-muted);
+    --p-combobox-border: var(--p-control-border);
+    --p-combobox-border-hover: var(--p-control-border-hover);
+    --p-combobox-border-focus: var(--p-control-border-focus);
+    --p-combobox-border-error: var(--p-control-border-error);
+    --p-combobox-ring: var(--p-control-ring);
+    --p-combobox-radius: var(--p-control-radius);
+    --p-combobox-min-height: var(--p-size-control-lg);
+    --p-combobox-option-min-height: var(--p-size-control-md);
+    --p-combobox-panel-max-height: 18rem;
+    --p-combobox-panel-width: 100%;
+    --p-combobox-padding-x: var(--p-control-padding-x);
+    --p-combobox-padding-top: var(--p-space-6);
+    --p-combobox-padding-bottom: var(--p-space-2);
+    --p-combobox-label-top: var(--p-space-2);
+    --p-combobox-placeholder-top: 50%;
+    --p-combobox-focus-ring-width: var(--p-focus-ring-width);
+    --p-combobox-message-margin-top: var(--p-control-message-margin-top);
+    --p-combobox-transition: var(--p-control-transition);
+
+    position: relative;
+    width: 100%;
+    max-width: 100%;
+    color: var(--p-combobox-text);
+    font-family: var(--p-font-family-sans);
+}
+
+.p-combobox__label {
+    position: absolute;
+    inset-inline-start: var(--p-combobox-padding-x);
+    max-width: calc(100% - var(--p-space-16));
+    overflow: hidden;
+    pointer-events: none;
+    text-overflow: ellipsis;
+    transform-origin: left;
+    white-space: nowrap;
+    font-family: var(--p-font-family-sans);
+    transition:
+        opacity var(--p-duration-fast) var(--p-ease-standard),
+        color var(--p-duration-fast) var(--p-ease-standard),
+        transform var(--p-duration-fast) var(--p-ease-standard);
+}
+
+.p-combobox__floating-label {
+    top: var(--p-combobox-label-top);
+    color: var(--p-combobox-text-muted);
+    font-size: var(--p-control-message-font-size);
+    line-height: var(--p-control-message-line-height);
+    opacity: 0;
+    transform: scale(0);
+}
+
+.p-combobox__placeholder-label {
+    top: var(--p-combobox-placeholder-top);
+    color: var(--p-combobox-text);
+    font-size: var(--p-control-font-size);
+    line-height: var(--p-control-line-height);
+    transform: translateY(-50%);
+}
+
+.p-combobox__field {
+    position: relative;
+    z-index: 1;
+}
+
+.p-combobox--open .p-combobox__field {
+    z-index: 60;
+}
+
+.p-combobox__hidden-input {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+    opacity: 0;
+    pointer-events: none;
+}
+
+.p-combobox__input {
+    width: 100%;
+    min-height: var(--p-combobox-min-height);
+    border: var(--p-control-border-width) solid var(--p-combobox-border);
+    border-radius: var(--p-combobox-radius);
+    background: var(--p-combobox-bg);
+    color: var(--p-combobox-text);
+    font-family: var(--p-font-family-sans);
+    font-size: var(--p-control-font-size);
+    line-height: var(--p-control-line-height);
+    outline: none;
+    padding-block: var(--p-combobox-padding-top)
+        var(--p-combobox-padding-bottom);
+    padding-inline: var(--p-combobox-padding-x) var(--p-space-12);
+    text-overflow: ellipsis;
+    transition: var(--p-combobox-transition);
+}
+
+.p-combobox__input--adorned {
+    padding-inline-end: var(--p-space-16);
+}
+
+.p-combobox__input::placeholder {
+    color: var(--p-combobox-text-muted);
+    opacity: 0;
+    transition: opacity var(--p-duration-fast) var(--p-ease-standard);
+}
+
+.p-combobox__input:hover {
+    border-color: var(--p-combobox-border-hover);
+    background: var(--p-combobox-bg-hover);
+}
+
+.p-combobox__input:focus {
+    border-color: var(--p-combobox-border-focus);
+    background: var(--p-combobox-bg-focus);
+    box-shadow: 0 0 0 var(--p-combobox-focus-ring-width) var(--p-combobox-ring);
+}
+
+.p-combobox__input:focus::placeholder {
+    opacity: 1;
+}
+
+.p-combobox__input:focus ~ .p-combobox__floating-label,
+.p-combobox__input:not(:placeholder-shown) ~ .p-combobox__floating-label {
+    opacity: 1;
+    transform: scale(1);
+}
+
+.p-combobox__input:focus ~ .p-combobox__floating-label {
+    color: var(--p-color-action-primary);
+}
+
+.p-combobox__input:focus ~ .p-combobox__placeholder-label,
+.p-combobox__input:not(:placeholder-shown) ~ .p-combobox__placeholder-label {
+    opacity: 0;
+    transform: translateY(-50%) scale(0);
+}
+
+.p-combobox__input:disabled {
+    cursor: not-allowed;
+}
+
+.p-combobox__input:disabled ~ .p-combobox__placeholder-label {
+    opacity: var(--p-opacity-disabled);
+}
+
+.p-combobox__input:read-only {
+    cursor: default;
+    background: var(--p-combobox-bg-readonly);
+}
+
+.p-combobox__label--error {
+    color: var(--p-combobox-border-error);
+}
+
+.p-combobox__clear,
+.p-combobox__chevron {
+    position: absolute;
+    top: 50%;
+    display: inline-flex;
+    width: var(--p-size-icon-md);
+    height: var(--p-size-icon-md);
+    align-items: center;
+    justify-content: center;
+    color: var(--p-combobox-text-muted);
+    transform: translateY(-50%);
+}
+
+.p-combobox__clear {
+    right: calc(
+        var(--p-combobox-padding-x) + var(--p-size-icon-md) + var(--p-space-2)
+    );
+    border-radius: var(--p-radius-xs);
+    transition: color var(--p-duration-fast) var(--p-ease-standard);
+}
+
+.p-combobox__clear:hover {
+    color: var(--p-combobox-text);
+}
+
+.p-combobox__clear:focus-visible {
+    outline: var(--p-focus-outline-width) solid var(--p-combobox-ring);
+    outline-offset: var(--p-focus-ring-offset);
+}
+
+.p-combobox__chevron {
+    right: var(--p-combobox-padding-x);
+    pointer-events: none;
+    transition: transform var(--p-duration-fast) var(--p-ease-standard);
+}
+
+.p-combobox--open .p-combobox__chevron {
+    transform: translateY(-50%) rotate(180deg);
+}
+
+.p-combobox__clear svg,
+.p-combobox__chevron svg,
+.p-combobox__option-check svg,
+.p-combobox__modal-close svg {
+    width: 100%;
+    height: 100%;
+}
+
+.p-combobox__backdrop,
+.p-combobox__modal-header,
+.p-combobox__modal-search {
+    display: none;
+}
+
+.p-combobox__panel {
+    position: absolute;
+    z-index: 70;
+    top: 100%;
+    left: 0;
+    width: var(--p-combobox-panel-width);
+    border: 1px solid var(--p-color-border);
+    border-radius: var(--p-combobox-radius);
+    background: var(--p-combobox-panel-bg);
+    box-shadow: var(--p-shadow-lg);
+    overflow: hidden;
+}
+
+.p-combobox__list {
+    max-height: var(--p-combobox-panel-max-height);
+    overflow: auto;
+    overscroll-behavior: contain;
+    padding-block: var(--p-space-2);
+}
+
+.p-combobox__group + .p-combobox__group {
+    margin-block-start: var(--p-space-2);
+    padding-block-start: var(--p-space-2);
+    border-block-start: 1px solid var(--p-color-border-subtle);
+}
+
+.p-combobox__group-label {
+    padding-block: var(--p-space-1);
+    padding-inline: var(--p-space-4);
+    color: var(--p-combobox-text-muted);
+    font-size: var(--p-font-size-caption);
+    font-weight: var(--p-font-weight-medium);
+    line-height: var(--p-line-height-caption);
+}
+
+.p-combobox__option {
+    display: grid;
+    grid-template-columns: var(--p-size-icon-md) minmax(0, 1fr) auto;
+    min-height: var(--p-combobox-option-min-height);
+    align-items: center;
+    gap: var(--p-space-3);
+    padding-block: var(--p-space-2);
+    padding-inline: var(--p-space-4);
+    color: var(--p-combobox-text);
+    cursor: pointer;
+    transition:
+        background-color var(--p-duration-fast) var(--p-ease-standard),
+        color var(--p-duration-fast) var(--p-ease-standard);
+}
+
+.p-combobox__option--active,
+.p-combobox__option:hover {
+    background: var(--p-color-surface-subtle);
+}
+
+.p-combobox__option--selected {
+    color: var(--p-color-action-primary);
+}
+
+.p-combobox__option--disabled {
+    cursor: not-allowed;
+    opacity: var(--p-opacity-disabled);
+}
+
+.p-combobox__option-check {
+    display: inline-flex;
+    width: var(--p-size-icon-md);
+    height: var(--p-size-icon-md);
+    align-items: center;
+    justify-content: center;
+    color: currentColor;
+}
+
+.p-combobox__option-content {
+    display: grid;
+    min-width: 0;
+    gap: var(--p-space-1);
+}
+
+.p-combobox__option-label,
+.p-combobox__option-description,
+.p-combobox__option-meta {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.p-combobox__option-label {
+    font-size: var(--p-font-size-body-sm);
+    font-weight: var(--p-font-weight-medium);
+    line-height: var(--p-line-height-body-sm);
+}
+
+.p-combobox__option-description,
+.p-combobox__option-meta {
+    color: var(--p-combobox-text-muted);
+    font-size: var(--p-font-size-caption);
+    line-height: var(--p-line-height-caption);
+}
+
+.p-combobox__option-meta {
+    justify-self: end;
+    padding-inline-start: var(--p-space-2);
+}
+
+.p-combobox__empty {
+    padding-block: var(--p-space-6);
+    padding-inline: var(--p-space-4);
+    color: var(--p-combobox-text-muted);
+    font-size: var(--p-font-size-body-sm);
+    line-height: var(--p-line-height-body-sm);
+    text-align: center;
+}
+
+.p-combobox__status {
+    display: flex;
+    min-height: var(--p-combobox-option-min-height);
+    align-items: center;
+    justify-content: center;
+    gap: var(--p-space-2);
+    padding-block: var(--p-space-3);
+    padding-inline: var(--p-space-4);
+    color: var(--p-combobox-text-muted);
+    font-size: var(--p-font-size-body-sm);
+    line-height: var(--p-line-height-body-sm);
+}
+
+.p-combobox__status--footer {
+    border-block-start: 1px solid var(--p-color-border-subtle);
+}
+
+.p-combobox__spinner {
+    width: var(--p-size-icon-sm);
+    height: var(--p-size-icon-sm);
+    flex: 0 0 auto;
+    border: 2px solid var(--p-color-border);
+    border-block-start-color: var(--p-color-action-primary);
+    border-radius: var(--p-radius-full);
+    animation: p-combobox-spin var(--p-duration-slow) linear infinite;
+}
+
+.p-combobox__footer {
+    border-block-start: 1px solid var(--p-color-border-subtle);
+    padding: var(--p-space-2);
+}
+
+.p-combobox__load-more {
+    width: 100%;
+    min-height: var(--p-size-control-md);
+    border-radius: var(--p-combobox-radius);
+    color: var(--p-color-action-primary);
+    font-size: var(--p-font-size-body-sm);
+    font-weight: var(--p-font-weight-medium);
+    line-height: var(--p-line-height-body-sm);
+    transition:
+        background-color var(--p-duration-fast) var(--p-ease-standard),
+        color var(--p-duration-fast) var(--p-ease-standard);
+}
+
+.p-combobox__load-more:hover {
+    background: var(--p-color-action-primary-subtle);
+}
+
+.p-combobox__load-more:focus-visible {
+    outline: var(--p-focus-outline-width) solid var(--p-combobox-ring);
+    outline-offset: var(--p-focus-ring-offset);
+}
+
+.p-combobox__message {
+    margin-block-start: var(--p-combobox-message-margin-top);
+    color: var(--p-combobox-text-muted);
+    font-size: var(--p-control-message-font-size);
+    line-height: var(--p-control-message-line-height);
+}
+
+.p-combobox__message--error {
+    color: var(--p-combobox-border-error);
+}
+
+.p-combobox--error .p-combobox__input {
+    border-color: var(--p-combobox-border-error);
+    box-shadow: 0 0 0 var(--p-combobox-focus-ring-width)
+        var(--p-combobox-border-error);
+}
+
+.p-combobox--disabled {
+    opacity: var(--p-opacity-disabled);
+}
+
+@keyframes p-combobox-spin {
+    to {
+        transform: rotate(360deg);
+    }
+}
+
+@media (max-width: 64rem) {
+    .p-combobox {
+        --p-combobox-panel-max-height: none;
+        --p-combobox-option-min-height: 3rem;
+    }
+
+    .p-combobox__backdrop {
+        position: fixed;
+        z-index: 40;
+        inset: 0;
+        display: block;
+        background: rgb(17 17 17 / 0.42);
+    }
+
+    .p-combobox__panel {
+        position: fixed;
+        z-index: 90;
+        top: 50%;
+        left: 50%;
+        display: flex;
+        width: min(calc(100vw - var(--p-space-8)), 36rem);
+        min-height: min(56dvh, 32rem);
+        max-height: min(38rem, calc(100dvh - var(--p-space-8)));
+        flex-direction: column;
+        border-color: var(--p-color-border-subtle);
+        transform: translate(-50%, -50%);
+    }
+
+    .p-combobox__modal-header {
+        display: flex;
+        min-height: var(--p-size-control-lg);
+        align-items: center;
+        justify-content: space-between;
+        gap: var(--p-space-3);
+        border-block-end: 1px solid var(--p-color-border-subtle);
+        padding-inline: var(--p-space-4);
+    }
+
+    .p-combobox__modal-search {
+        display: block;
+        border-block-end: 1px solid var(--p-color-border-subtle);
+        padding: var(--p-space-3) var(--p-space-4);
+    }
+
+    .p-combobox__modal-input {
+        width: 100%;
+        min-height: var(--p-size-control-lg);
+        border: var(--p-control-border-width) solid var(--p-combobox-border);
+        border-radius: var(--p-combobox-radius);
+        background: var(--p-combobox-bg);
+        color: var(--p-combobox-text);
+        font-family: var(--p-font-family-sans);
+        font-size: var(--p-control-font-size);
+        line-height: var(--p-control-line-height);
+        outline: none;
+        padding-block: var(--p-control-padding-y);
+        padding-inline: var(--p-combobox-padding-x);
+        transition: var(--p-combobox-transition);
+    }
+
+    .p-combobox__modal-input::placeholder {
+        color: var(--p-combobox-text-muted);
+        opacity: 1;
+    }
+
+    .p-combobox__modal-input:focus {
+        border-color: var(--p-combobox-border-focus);
+        background: var(--p-combobox-bg-focus);
+        box-shadow: 0 0 0 var(--p-combobox-focus-ring-width)
+            var(--p-combobox-ring);
+    }
+
+    .p-combobox__modal-title {
+        min-width: 0;
+        overflow: hidden;
+        color: var(--p-combobox-text);
+        font-size: var(--p-font-size-body-sm);
+        font-weight: var(--p-font-weight-medium);
+        line-height: var(--p-line-height-body-sm);
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+
+    .p-combobox__modal-close {
+        display: inline-flex;
+        width: var(--p-size-control-sm);
+        height: var(--p-size-control-sm);
+        flex: 0 0 auto;
+        align-items: center;
+        justify-content: center;
+        border-radius: var(--p-radius-xs);
+        color: var(--p-combobox-text-muted);
+    }
+
+    .p-combobox__modal-close:hover {
+        background: var(--p-color-surface-subtle);
+        color: var(--p-combobox-text);
+    }
+
+    .p-combobox__modal-close:focus-visible {
+        outline: var(--p-focus-outline-width) solid var(--p-combobox-ring);
+        outline-offset: var(--p-focus-ring-offset);
+    }
+
+    .p-combobox__modal-close svg {
+        width: var(--p-size-icon-md);
+        height: var(--p-size-icon-md);
+    }
+
+    .p-combobox__list {
+        min-height: 0;
+        max-height: none;
+        flex: 1 1 auto;
+    }
+
+    .p-combobox__option {
+        grid-template-columns: var(--p-size-icon-md) minmax(0, 1fr);
+    }
+
+    .p-combobox__option-meta {
+        grid-column: 2;
+        justify-self: start;
+        padding-inline-start: 0;
+    }
+}
+
+@media (max-width: 40rem) {
+    .p-combobox__panel {
+        top: auto;
+        right: 0;
+        bottom: 0;
+        left: 0;
+        width: 100%;
+        min-height: 50dvh;
+        max-height: min(85dvh, 42rem);
+        border-inline: 0;
+        border-block-end: 0;
+        border-radius: var(--p-radius-lg) var(--p-radius-lg) 0 0;
+        transform: none;
+    }
+}

--- a/src/components/PCombobox/PCombobox.stories.tsx
+++ b/src/components/PCombobox/PCombobox.stories.tsx
@@ -1,0 +1,393 @@
+import { useEffect, useMemo, useState } from 'react';
+import { type Meta, type StoryObj } from '@storybook/react';
+import { PCombobox, type PComboboxOption } from '.';
+import { PTextInput } from '../PTextInput';
+
+const peopleOptions: PComboboxOption[] = [
+  {
+    value: 'ava-rodriguez',
+    label: 'Ava Rodriguez',
+    description: 'VP Operations',
+    group: 'Leadership',
+    meta: 'US',
+    keywords: ['ops', 'executive'],
+  },
+  {
+    value: 'marcus-chen',
+    label: 'Marcus Chen',
+    description: 'Enterprise Account Director',
+    group: 'Sales',
+    meta: 'APAC',
+    keywords: ['accounts', 'revenue'],
+  },
+  {
+    value: 'nina-patel',
+    label: 'Nina Patel',
+    description: 'Principal Solutions Architect',
+    group: 'Technical',
+    meta: 'EMEA',
+    keywords: ['architecture', 'implementation'],
+  },
+  {
+    value: 'samuel-lee',
+    label: 'Samuel Lee',
+    description: 'Security Review Lead',
+    group: 'Technical',
+    meta: 'SOC 2',
+    keywords: ['security', 'compliance'],
+  },
+  {
+    value: 'elena-wright',
+    label: 'Elena Wright',
+    description: 'Finance Partner',
+    group: 'Finance',
+    meta: 'FY26',
+    keywords: ['budget', 'procurement'],
+  },
+  {
+    value: 'blocked-vendor',
+    label: 'Legacy Vendor Queue',
+    description: 'Unavailable while procurement is locked',
+    group: 'Finance',
+    meta: 'Locked',
+    disabled: true,
+  },
+];
+
+const accountOptions: PComboboxOption[] = [
+  { value: 'northstar-bank', label: 'Northstar Bank', description: 'Strategic account', meta: 'Tier 1' },
+  { value: 'atlas-health', label: 'Atlas Health', description: 'Renewal in progress', meta: 'Q3' },
+  { value: 'helio-grid', label: 'Helio Grid', description: 'Security review pending', meta: 'Risk' },
+  { value: 'summit-retail', label: 'Summit Retail', description: 'Expansion opportunity', meta: 'Plus' },
+  { value: 'cobalt-air', label: 'Cobalt Air', description: 'Implementation complete', meta: 'Live' },
+];
+
+const accountDirectoryOptions: PComboboxOption[] = Array.from({ length: 72 }, (_, index) => {
+  const regions = ['North America', 'EMEA', 'APAC', 'LATAM'];
+  const stages = ['Discovery', 'Security review', 'Implementation', 'Renewal', 'Expansion', 'Procurement'];
+  const tiers = ['Tier 1', 'Tier 2', 'Strategic'];
+  const number = index + 1;
+  const region = regions[index % regions.length];
+  const stage = stages[index % stages.length];
+
+  return {
+    value: `account-${number}`,
+    label: `${['Northstar', 'Atlas', 'Helio', 'Summit', 'Cobalt', 'Vector'][index % 6]} ${number}`,
+    description: `${stage} account in ${region}`,
+    group: region,
+    meta: tiers[index % tiers.length],
+    keywords: [stage, region, tiers[index % tiers.length]],
+  };
+});
+
+const asyncPageSize = 12;
+
+function AsyncInfiniteComboboxExample() {
+  const [query, setQuery] = useState('');
+  const [options, setOptions] = useState<PComboboxOption[]>([]);
+  const [selectedValue, setSelectedValue] = useState('');
+  const [selectedOption, setSelectedOption] = useState<PComboboxOption | null>(null);
+  const [page, setPage] = useState(0);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isLoadingMore, setIsLoadingMore] = useState(false);
+  const [hasMore, setHasMore] = useState(false);
+
+  const matchingOptions = useMemo(() => {
+    const normalizedQuery = query.trim().toLocaleLowerCase();
+
+    if (!normalizedQuery) {
+      return accountDirectoryOptions;
+    }
+
+    return accountDirectoryOptions.filter((option) =>
+      [option.label, option.description, option.group, option.meta, ...(option.keywords ?? [])]
+        .filter(Boolean)
+        .join(' ')
+        .toLocaleLowerCase()
+        .includes(normalizedQuery),
+    );
+  }, [query]);
+
+  useEffect(() => {
+    setIsLoading(true);
+    setOptions([]);
+    setPage(0);
+
+    const timeoutId = setTimeout(() => {
+      setOptions(matchingOptions.slice(0, asyncPageSize));
+      setHasMore(matchingOptions.length > asyncPageSize);
+      setIsLoading(false);
+    }, 320);
+
+    return () => clearTimeout(timeoutId);
+  }, [matchingOptions]);
+
+  const handleLoadMore = () => {
+    if (isLoadingMore) {
+      return;
+    }
+
+    setIsLoadingMore(true);
+
+    setTimeout(() => {
+      const nextPage = page + 1;
+      const nextOptions = matchingOptions.slice(0, (nextPage + 1) * asyncPageSize);
+
+      setOptions(nextOptions);
+      setPage(nextPage);
+      setHasMore(nextOptions.length < matchingOptions.length);
+      setIsLoadingMore(false);
+    }, 360);
+  };
+
+  return (
+    <PCombobox
+      label="Account API"
+      options={options}
+      value={selectedValue}
+      selectedOption={selectedOption}
+      query={query}
+      filterMode="none"
+      isLoading={isLoading}
+      isLoadingMore={isLoadingMore}
+      hasMore={hasMore}
+      onLoadMore={handleLoadMore}
+      onQueryChange={(nextQuery, details) => {
+        if (details.source === 'input' || details.source === 'open' || details.source === 'clear') {
+          setQuery(nextQuery);
+        }
+      }}
+      onValueChange={(nextValue, option) => {
+        setSelectedValue(nextValue);
+        setSelectedOption(option);
+      }}
+      placeholder="Search account directory"
+      searchPlaceholder="Type an account, stage, or region"
+      emptyText="No accounts match this search."
+      loadingText="Loading accounts..."
+      loadingMoreText="Loading more accounts..."
+      loadMoreText="Load next page"
+      helperText="Remote mode: parent owns API search, option pages, and selected records."
+    />
+  );
+}
+
+function SelectedOptionMismatchExample() {
+  return (
+    <PCombobox
+      label="Mismatched owner"
+      options={peopleOptions}
+      value="nina-patel"
+      selectedOption={peopleOptions[0]}
+      helperText="The displayed label must follow the selected value, not a stale selectedOption object."
+    />
+  );
+}
+
+const meta: Meta<typeof PCombobox> = {
+  title: 'Components/PCombobox',
+  component: PCombobox,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered',
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ width: 380 }}>
+        <Story />
+      </div>
+    ),
+  ],
+  args: {
+    label: 'Owner',
+    options: peopleOptions,
+  },
+  argTypes: {
+    label: {
+      description: 'Visible field label.',
+    },
+    options: {
+      description: 'Searchable listbox options. Descriptions, groups, metadata, keywords, and disabled rows are supported.',
+    },
+    value: {
+      description: 'Controlled selected option value.',
+    },
+    defaultValue: {
+      description: 'Initial selected option value for uncontrolled usage.',
+    },
+    onValueChange: {
+      description: 'Called with the option value and full option record. Clear emits an empty value and null option.',
+    },
+    query: {
+      description: 'Controlled search query for remote/API-backed comboboxes.',
+    },
+    onQueryChange: {
+      description: 'Called when the user searches, opens, clears, selects, or resets the combobox query.',
+    },
+    filterMode: {
+      control: 'select',
+      options: ['local', 'none'],
+      description: 'Use local for built-in filtering or none when options already come filtered from an API.',
+    },
+    isLoading: {
+      description: 'Shows an initial or refreshing loading state while remote options are being fetched.',
+    },
+    isLoadingMore: {
+      description: 'Shows the paginated loading state at the bottom of the list.',
+    },
+    hasMore: {
+      description: 'Signals that additional pages are available.',
+    },
+    onLoadMore: {
+      description: 'Called when the scroll area reaches the end or the user activates the load-more action.',
+    },
+    placeholder: {
+      description: 'Text shown before a value is selected.',
+    },
+    searchPlaceholder: {
+      description: 'Text shown while the listbox is open.',
+    },
+    emptyText: {
+      description: 'Shown when no options match the search query.',
+    },
+    helperText: {
+      description: 'Shown below the combobox when there is no error.',
+    },
+    isError: {
+      description: 'Puts the combobox into an error state.',
+    },
+    errorMessage: {
+      description: 'Shown below the combobox when `isError` is true.',
+    },
+    clearable: {
+      description: 'Shows a clear action when a value is selected.',
+    },
+  },
+};
+
+type Story = StoryObj<typeof PCombobox>;
+
+export const Standard: Story = {
+  name: 'Standard',
+  args: {
+    label: 'Account owner',
+    placeholder: 'Select owner',
+    helperText: 'Search by name, role, region, or responsibility.',
+  },
+};
+
+export const Filled: Story = {
+  name: 'Filled',
+  args: {
+    label: 'Account owner',
+    defaultValue: 'nina-patel',
+    helperText: 'Selected values submit through the hidden form input.',
+  },
+};
+
+export const AccountPicker: Story = {
+  name: 'Account Picker',
+  args: {
+    label: 'Account',
+    options: accountOptions,
+    placeholder: 'Select account',
+    searchPlaceholder: 'Search accounts',
+    helperText: 'Optimized for dense enterprise records with status metadata.',
+  },
+};
+
+export const AsyncInfiniteLoading: Story = {
+  name: 'Async Infinite Loading',
+  render: () => <AsyncInfiniteComboboxExample />,
+};
+
+export const WithoutClear: Story = {
+  name: 'Without Clear',
+  args: {
+    label: 'Required owner',
+    defaultValue: 'ava-rodriguez',
+    clearable: false,
+    required: true,
+  },
+};
+
+export const SelectedOptionMismatch: Story = {
+  name: 'Selected Option Mismatch',
+  render: () => <SelectedOptionMismatchExample />,
+};
+
+export const RequiredFormField: Story = {
+  name: 'Required Form Field',
+  render: () => (
+    <form>
+      <PCombobox
+        label="Required approver"
+        name="approvalOwner"
+        options={peopleOptions}
+        placeholder="Select approver"
+        required
+      />
+      <button type="submit">Submit</button>
+    </form>
+  ),
+};
+
+export const EmptyResults: Story = {
+  name: 'Empty Results',
+  args: {
+    label: 'Region',
+    options: [],
+    emptyText: 'No regions are available.',
+  },
+};
+
+export const WithError: Story = {
+  name: 'With Error',
+  args: {
+    label: 'Approval owner',
+    isError: true,
+    errorMessage: 'Select an approval owner before submitting.',
+  },
+};
+
+export const ReadOnly: Story = {
+  name: 'Read Only',
+  args: {
+    label: 'Locked owner',
+    defaultValue: 'samuel-lee',
+    readOnly: true,
+    helperText: 'This assignment is managed by policy.',
+  },
+};
+
+export const Disabled: Story = {
+  name: 'Disabled',
+  args: {
+    label: 'Disabled owner',
+    defaultValue: 'elena-wright',
+    disabled: true,
+  },
+};
+
+export const EnterpriseFormFlow: Story = {
+  name: 'Enterprise Form Flow',
+  render: () => (
+    <div style={{ display: 'grid', gap: '1rem', width: 380 }}>
+      <PTextInput label="Opportunity name" defaultValue="Global support renewal" />
+      <PCombobox
+        label="Account"
+        options={accountOptions}
+        defaultValue="northstar-bank"
+        helperText="Desktop and tablet use an anchored listbox; mobile expands inline below the field."
+      />
+      <PCombobox label="Approval owner" options={peopleOptions} placeholder="Select approver" required />
+      <PTextInput label="Reference" />
+    </div>
+  ),
+  parameters: {
+    layout: 'centered',
+  },
+  decorators: [(Story) => <Story />],
+};
+
+export default meta;

--- a/src/components/PCombobox/PCombobox.tsx
+++ b/src/components/PCombobox/PCombobox.tsx
@@ -1,0 +1,726 @@
+import {
+  forwardRef,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+  type ChangeEvent,
+  type FocusEvent,
+  type ForwardedRef,
+  type HTMLAttributes,
+  type KeyboardEvent,
+  type MouseEvent,
+  type ReactNode,
+  type UIEvent,
+} from 'react';
+import cn from '../../utils/cn';
+import './PCombobox.css';
+
+export type PComboboxRef = HTMLDivElement;
+export type PComboboxFilterMode = 'local' | 'none';
+export type PComboboxQueryChangeSource = 'input' | 'open' | 'clear' | 'selection' | 'reset';
+
+export type PComboboxOption = {
+  value: string;
+  label: string;
+  description?: string;
+  group?: string;
+  meta?: ReactNode;
+  keywords?: string[];
+  disabled?: boolean;
+};
+
+export type PComboboxProps = {
+  label: string;
+  options: PComboboxOption[];
+  value?: string;
+  defaultValue?: string;
+  selectedOption?: PComboboxOption | null;
+  onValueChange?: (value: string, option: PComboboxOption | null) => void;
+  query?: string;
+  defaultQuery?: string;
+  onQueryChange?: (query: string, details: { source: PComboboxQueryChangeSource }) => void;
+  filterMode?: PComboboxFilterMode;
+  isLoading?: boolean;
+  isLoadingMore?: boolean;
+  hasMore?: boolean;
+  onLoadMore?: (details: { query: string; optionCount: number }) => void;
+  placeholder?: string;
+  searchPlaceholder?: string;
+  emptyText?: string;
+  loadingText?: string;
+  loadingMoreText?: string;
+  loadMoreText?: string;
+  helperText?: string;
+  isError?: boolean;
+  errorMessage?: string;
+  name?: string;
+  disabled?: boolean;
+  readOnly?: boolean;
+  required?: boolean;
+  clearable?: boolean;
+  className?: string;
+  inputClassName?: string;
+} & Omit<HTMLAttributes<HTMLDivElement>, 'className' | 'defaultValue' | 'onChange'>;
+
+type ContainsElement = {
+  contains: (target: EventTarget | null) => boolean;
+};
+
+type FocusableElement = {
+  focus: () => void;
+};
+
+type ScrollableElement = {
+  scrollIntoView: (options?: { block?: 'nearest' }) => void;
+};
+
+type ScrollMetricsElement = {
+  scrollTop: number;
+  clientHeight: number;
+  scrollHeight: number;
+};
+
+type ValidatableElement = {
+  setCustomValidity: (error: string) => void;
+};
+
+type ViewportMatcher = {
+  matchMedia?: (query: string) => {
+    matches: boolean;
+    addEventListener?: (type: 'change', listener: () => void) => void;
+    removeEventListener?: (type: 'change', listener: () => void) => void;
+  };
+};
+
+function ChevronDownIcon() {
+  return (
+    <svg viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="1.75" aria-hidden="true">
+      <path d="m5 8 5 5 5-5" />
+    </svg>
+  );
+}
+
+function CheckIcon() {
+  return (
+    <svg viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="1.75" aria-hidden="true">
+      <path d="m4 10 4 4 8-8" />
+    </svg>
+  );
+}
+
+function XIcon() {
+  return (
+    <svg viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="1.75" aria-hidden="true">
+      <path d="m5 5 10 10" />
+      <path d="m15 5-10 10" />
+    </svg>
+  );
+}
+
+function normalizeText(value: string) {
+  return value.trim().toLocaleLowerCase();
+}
+
+function filterOptions(options: PComboboxOption[], query: string) {
+  const normalizedQuery = normalizeText(query);
+
+  if (!normalizedQuery) {
+    return options;
+  }
+
+  return options.filter((option) => {
+    const searchableText = [
+      option.label,
+      option.value,
+      option.description,
+      option.group,
+      ...(option.keywords ?? []),
+    ]
+      .filter(Boolean)
+      .join(' ');
+
+    return normalizeText(searchableText).includes(normalizedQuery);
+  });
+}
+
+function getFirstEnabledIndex(options: PComboboxOption[]) {
+  return options.findIndex((option) => !option.disabled);
+}
+
+function getSelectedIndex(options: PComboboxOption[], selectedValue: string | undefined) {
+  const selectedIndex = options.findIndex((option) => option.value === selectedValue && !option.disabled);
+
+  return selectedIndex >= 0 ? selectedIndex : getFirstEnabledIndex(options);
+}
+
+function getNextEnabledIndex(options: PComboboxOption[], activeIndex: number, direction: 1 | -1) {
+  if (!options.length) {
+    return -1;
+  }
+
+  let nextIndex = activeIndex;
+
+  for (let attempt = 0; attempt < options.length; attempt += 1) {
+    nextIndex = (nextIndex + direction + options.length) % options.length;
+
+    if (!options[nextIndex]?.disabled) {
+      return nextIndex;
+    }
+  }
+
+  return -1;
+}
+
+function assignRef(ref: ForwardedRef<PComboboxRef>, node: PComboboxRef | null) {
+  if (typeof ref === 'function') {
+    ref(node);
+    return;
+  }
+
+  if (ref) {
+    ref.current = node;
+  }
+}
+
+export const PCombobox = forwardRef<PComboboxRef, PComboboxProps>(
+  (
+    {
+      label,
+      options,
+      value,
+      defaultValue,
+      selectedOption: selectedOptionProp,
+      onValueChange,
+      query: queryProp,
+      defaultQuery,
+      onQueryChange,
+      filterMode = 'local',
+      isLoading = false,
+      isLoadingMore = false,
+      hasMore = false,
+      onLoadMore,
+      placeholder = 'Select an option',
+      searchPlaceholder = 'Search options',
+      emptyText = 'No options found.',
+      loadingText = 'Loading options...',
+      loadingMoreText = 'Loading more options...',
+      loadMoreText = 'Load more options',
+      helperText,
+      isError = false,
+      errorMessage,
+      name,
+      disabled = false,
+      readOnly = false,
+      required = false,
+      clearable = true,
+      className,
+      inputClassName,
+      id,
+      style,
+      ...props
+    },
+    ref,
+  ) => {
+    const generatedId = useId();
+    const rootId = id ?? generatedId;
+    const labelId = `${rootId}-label`;
+    const inputId = `${rootId}-input`;
+    const listboxId = `${rootId}-listbox`;
+    const helperId = `${rootId}-helper`;
+    const errorId = `${rootId}-error`;
+    const rootRef = useRef<HTMLDivElement | null>(null);
+    const inputRef = useRef<(HTMLInputElement & FocusableElement) | null>(null);
+    const modalInputRef = useRef<(HTMLInputElement & FocusableElement) | null>(null);
+    const hiddenInputRef = useRef<(HTMLInputElement & ValidatableElement) | null>(null);
+    const activeOptionRef = useRef<ScrollableElement | null>(null);
+    const panelRef = useRef<ScrollMetricsElement | null>(null);
+    const isControlled = value !== undefined;
+    const isQueryControlled = queryProp !== undefined;
+    const [internalValue, setInternalValue] = useState(defaultValue ?? '');
+    const selectedValue = isControlled ? value : internalValue;
+    const selectedOption =
+      selectedOptionProp?.value === selectedValue
+        ? selectedOptionProp
+        : options.find((option) => option.value === selectedValue) ?? null;
+    const [internalQuery, setInternalQuery] = useState(defaultQuery ?? selectedOption?.label ?? '');
+    const query = isQueryControlled ? queryProp : internalQuery;
+    const [isOpen, setIsOpen] = useState(false);
+    const [isModalViewport, setIsModalViewport] = useState(false);
+    const filteredOptions = useMemo(
+      () => (filterMode === 'local' ? filterOptions(options, query) : options),
+      [filterMode, options, query],
+    );
+    const [activeIndex, setActiveIndex] = useState(() => getSelectedIndex(options, selectedValue));
+    const activeOption = isOpen ? filteredOptions[activeIndex] : undefined;
+    const activeOptionId = activeOption ? `${listboxId}-option-${activeIndex}` : undefined;
+    const modalTitleId = `${rootId}-modal-title`;
+    const messageId = isError && errorMessage ? errorId : helperText ? helperId : undefined;
+    const hasSelection = Boolean(selectedOption);
+    const canClear = clearable && hasSelection && !disabled && !readOnly;
+    const inputValue = isOpen ? query : selectedOption?.label ?? query;
+    const showInitialLoading = isLoading && filteredOptions.length === 0;
+    const showFooterLoading = isLoadingMore || (isLoading && filteredOptions.length > 0);
+    const showLoadMore = Boolean(hasMore && onLoadMore && !isLoading && !isLoadingMore);
+
+    useEffect(() => {
+      if (!isOpen && !isQueryControlled) {
+        setInternalQuery(selectedOption?.label ?? '');
+      }
+    }, [isOpen, isQueryControlled, selectedOption]);
+
+    useEffect(() => {
+      if (!isOpen) {
+        return;
+      }
+
+      setActiveIndex((currentIndex) => {
+        if (filteredOptions[currentIndex] && !filteredOptions[currentIndex].disabled) {
+          return currentIndex;
+        }
+
+        return getSelectedIndex(filteredOptions, selectedValue);
+      });
+    }, [filteredOptions, isOpen, selectedValue]);
+
+    useEffect(() => {
+      if (!isOpen) {
+        return;
+      }
+
+      activeOptionRef.current?.scrollIntoView({ block: 'nearest' });
+    }, [activeIndex, isOpen]);
+
+    useEffect(() => {
+      const matcher = globalThis as unknown as ViewportMatcher;
+      const mediaQuery = matcher.matchMedia?.('(max-width: 64rem)');
+
+      if (!mediaQuery) {
+        return;
+      }
+
+      const syncModalViewport = () => setIsModalViewport(mediaQuery.matches);
+      syncModalViewport();
+      mediaQuery.addEventListener?.('change', syncModalViewport);
+
+      return () => mediaQuery.removeEventListener?.('change', syncModalViewport);
+    }, []);
+
+    useEffect(() => {
+      if (!isOpen || !isModalViewport) {
+        return;
+      }
+
+      modalInputRef.current?.focus();
+    }, [isModalViewport, isOpen]);
+
+    useEffect(() => {
+      if (!hiddenInputRef.current) {
+        return;
+      }
+
+      hiddenInputRef.current.setCustomValidity(required && !selectedValue ? 'Select an option.' : '');
+    }, [required, selectedValue]);
+
+    const setRootRef = (node: HTMLDivElement | null) => {
+      rootRef.current = node;
+      assignRef(ref, node);
+    };
+
+    const setSearchQuery = (nextQuery: string, source: PComboboxQueryChangeSource) => {
+      if (!isQueryControlled) {
+        setInternalQuery(nextQuery);
+      }
+
+      onQueryChange?.(nextQuery, { source });
+    };
+
+    const requestLoadMore = () => {
+      if (!hasMore || !onLoadMore || isLoading || isLoadingMore) {
+        return;
+      }
+
+      onLoadMore({ query, optionCount: filteredOptions.length });
+    };
+
+    useEffect(() => {
+      if (!isOpen || !panelRef.current) {
+        return;
+      }
+
+      const { scrollHeight, clientHeight } = panelRef.current;
+
+      if (scrollHeight <= clientHeight + 48) {
+        requestLoadMore();
+      }
+    });
+
+    const commitValue = (nextOption: PComboboxOption | null) => {
+      const nextValue = nextOption?.value ?? '';
+
+      if (!isControlled) {
+        setInternalValue(nextValue);
+      }
+
+      setSearchQuery(nextOption?.label ?? '', nextOption ? 'selection' : 'clear');
+      onValueChange?.(nextValue, nextOption);
+    };
+
+    const openCombobox = (nextQuery = query) => {
+      if (disabled || readOnly) {
+        return;
+      }
+
+      const nextOptions = filterMode === 'local' ? filterOptions(options, nextQuery) : options;
+      setSearchQuery(nextQuery, 'open');
+      setActiveIndex(getSelectedIndex(nextOptions, selectedValue));
+      setIsOpen(true);
+    };
+
+    const closeCombobox = () => {
+      setIsOpen(false);
+      setSearchQuery(selectedOption?.label ?? '', 'reset');
+    };
+
+    const handleInputChange = (event: ChangeEvent<HTMLInputElement>) => {
+      const nextQuery = (event.currentTarget as unknown as { value: string }).value;
+      const nextOptions = filterMode === 'local' ? filterOptions(options, nextQuery) : options;
+
+      setSearchQuery(nextQuery, 'input');
+      setActiveIndex(getFirstEnabledIndex(nextOptions));
+      setIsOpen(true);
+    };
+
+    const handleInputKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+      if (event.key === 'ArrowDown') {
+        event.preventDefault();
+
+        if (!isOpen) {
+          openCombobox('');
+          return;
+        }
+
+        setActiveIndex((currentIndex) => getNextEnabledIndex(filteredOptions, currentIndex, 1));
+        return;
+      }
+
+      if (event.key === 'ArrowUp') {
+        event.preventDefault();
+
+        if (!isOpen) {
+          openCombobox('');
+          return;
+        }
+
+        setActiveIndex((currentIndex) => getNextEnabledIndex(filteredOptions, currentIndex, -1));
+        return;
+      }
+
+      if (event.key === 'Enter') {
+        if (!isOpen) {
+          openCombobox(query);
+          return;
+        }
+
+        if (activeOption && !activeOption.disabled) {
+          event.preventDefault();
+          commitValue(activeOption);
+          setIsOpen(false);
+        }
+
+        return;
+      }
+
+      if (event.key === 'Escape' && isOpen) {
+        event.preventDefault();
+        closeCombobox();
+        return;
+      }
+
+      if (event.key === 'Tab') {
+        closeCombobox();
+      }
+    };
+
+    const handleOptionPointerDown = (event: MouseEvent<HTMLDivElement>, option: PComboboxOption) => {
+      event.preventDefault();
+
+      if (option.disabled) {
+        return;
+      }
+
+      commitValue(option);
+      setIsOpen(false);
+      inputRef.current?.focus();
+    };
+
+    const handleClear = (event: MouseEvent<HTMLButtonElement>) => {
+      event.preventDefault();
+      event.stopPropagation();
+      commitValue(null);
+      setIsOpen(false);
+      inputRef.current?.focus();
+    };
+
+    const handlePanelScroll = (event: UIEvent<HTMLDivElement>) => {
+      const panel = event.currentTarget as unknown as ScrollMetricsElement;
+      const distanceToBottom = panel.scrollHeight - panel.scrollTop - panel.clientHeight;
+
+      if (distanceToBottom <= 48) {
+        requestLoadMore();
+      }
+    };
+
+    const handleBlur = (event: FocusEvent<HTMLDivElement>) => {
+      if (!isOpen) {
+        return;
+      }
+
+      const currentTarget = event.currentTarget as unknown as ContainsElement;
+
+      if (!currentTarget.contains(event.relatedTarget)) {
+        closeCombobox();
+      }
+    };
+
+    const groups = filteredOptions.reduce<Array<{ group: string | null; options: PComboboxOption[] }>>(
+      (accumulator, option) => {
+        const group = option.group ?? null;
+        const existingGroup = accumulator.find((item) => item.group === group);
+
+        if (existingGroup) {
+          existingGroup.options.push(option);
+          return accumulator;
+        }
+
+        accumulator.push({ group, options: [option] });
+        return accumulator;
+      },
+      [],
+    );
+
+    return (
+      <div
+        {...props}
+        ref={setRootRef}
+        id={rootId}
+        style={style}
+        onBlur={handleBlur}
+        className={cn(
+          'p-combobox',
+          isOpen && 'p-combobox--open',
+          isError && 'p-combobox--error',
+          disabled && 'p-combobox--disabled',
+          readOnly && 'p-combobox--readonly',
+          className,
+        )}
+      >
+        <div className="p-combobox__field">
+          <input
+            ref={inputRef}
+            id={inputId}
+            role="combobox"
+            type="text"
+            value={inputValue}
+            placeholder={isOpen ? searchPlaceholder : ' '}
+            disabled={disabled}
+            readOnly={readOnly}
+            required={false}
+            aria-autocomplete="list"
+            aria-controls={listboxId}
+            aria-describedby={messageId}
+            aria-activedescendant={activeOptionId}
+            aria-expanded={isOpen}
+            aria-haspopup="listbox"
+            aria-invalid={isError || undefined}
+            aria-labelledby={labelId}
+            autoComplete="off"
+            className={cn('p-combobox__input', (canClear || hasSelection) && 'p-combobox__input--adorned', inputClassName)}
+            onChange={handleInputChange}
+            onClick={() => openCombobox('')}
+            onKeyDown={handleInputKeyDown}
+          />
+
+          <label
+            id={labelId}
+            htmlFor={inputId}
+            className={cn('p-combobox__label p-combobox__floating-label', isError && 'p-combobox__label--error')}
+          >
+            {label}
+          </label>
+
+          <span aria-hidden="true" className="p-combobox__label p-combobox__placeholder-label">
+            {placeholder || label}
+          </span>
+
+          {canClear ? (
+            <button
+              type="button"
+              className="p-combobox__clear"
+              aria-label={`Clear ${label}`}
+              onMouseDown={handleClear}
+            >
+              <XIcon />
+            </button>
+          ) : null}
+
+          <span className="p-combobox__chevron" aria-hidden="true">
+            <ChevronDownIcon />
+          </span>
+
+          {isOpen ? (
+            <div
+              className="p-combobox__panel"
+              role={isModalViewport ? 'dialog' : undefined}
+              aria-modal={isModalViewport || undefined}
+              aria-labelledby={isModalViewport ? modalTitleId : undefined}
+            >
+              <div className="p-combobox__modal-header">
+                <div id={modalTitleId} className="p-combobox__modal-title">{label}</div>
+                <button type="button" className="p-combobox__modal-close" aria-label={`Close ${label}`} onClick={closeCombobox}>
+                  <XIcon />
+                </button>
+              </div>
+              <div className="p-combobox__modal-search">
+                <input
+                  ref={modalInputRef}
+                  role="combobox"
+                  type="search"
+                  value={query}
+                  placeholder={searchPlaceholder}
+                  aria-activedescendant={activeOptionId}
+                  aria-autocomplete="list"
+                  aria-controls={listboxId}
+                  aria-expanded={isOpen}
+                  aria-haspopup="listbox"
+                  aria-label={`Search ${label}`}
+                  autoComplete="off"
+                  className="p-combobox__modal-input"
+                  onChange={handleInputChange}
+                  onKeyDown={handleInputKeyDown}
+                />
+              </div>
+
+              <div
+                id={listboxId}
+                ref={(node) => {
+                  panelRef.current = node as unknown as ScrollMetricsElement | null;
+                }}
+                role="listbox"
+                aria-busy={isLoading || isLoadingMore || undefined}
+                aria-labelledby={labelId}
+                className="p-combobox__list"
+                onScroll={handlePanelScroll}
+              >
+                {showInitialLoading ? (
+                  <div className="p-combobox__status" role="option" aria-disabled="true" aria-selected="false">
+                    <span className="p-combobox__spinner" aria-hidden="true" />
+                    <span>{loadingText}</span>
+                  </div>
+                ) : null}
+
+                {groups.length ? (
+                  groups.map((group) => (
+                    <div key={group.group ?? 'ungrouped'} className="p-combobox__group">
+                      {group.group ? <div className="p-combobox__group-label">{group.group}</div> : null}
+                      {group.options.map((option) => {
+                        const optionIndex = filteredOptions.indexOf(option);
+                        const isActive = optionIndex === activeIndex;
+                        const isSelected = option.value === selectedValue;
+
+                        return (
+                          <div
+                            key={option.value}
+                            ref={
+                              isActive
+                                ? (node) => {
+                                    activeOptionRef.current = node as unknown as ScrollableElement | null;
+                                  }
+                                : undefined
+                            }
+                            id={`${listboxId}-option-${optionIndex}`}
+                            role="option"
+                            aria-disabled={option.disabled || undefined}
+                            aria-selected={isSelected}
+                            className={cn(
+                              'p-combobox__option',
+                              isActive && 'p-combobox__option--active',
+                              isSelected && 'p-combobox__option--selected',
+                              option.disabled && 'p-combobox__option--disabled',
+                            )}
+                            onMouseDown={(event) => handleOptionPointerDown(event, option)}
+                          >
+                            <span className="p-combobox__option-check">
+                              {isSelected ? <CheckIcon /> : null}
+                            </span>
+                            <span className="p-combobox__option-content">
+                              <span className="p-combobox__option-label">{option.label}</span>
+                              {option.description ? (
+                                <span className="p-combobox__option-description">{option.description}</span>
+                              ) : null}
+                            </span>
+                            {option.meta ? <span className="p-combobox__option-meta">{option.meta}</span> : null}
+                          </div>
+                        );
+                      })}
+                    </div>
+                  ))
+                ) : !showInitialLoading ? (
+                  <div className="p-combobox__empty" role="option" aria-disabled="true" aria-selected="false">
+                    {emptyText}
+                  </div>
+                ) : null}
+
+                {showFooterLoading ? (
+                  <div className="p-combobox__status p-combobox__status--footer" role="option" aria-disabled="true" aria-selected="false">
+                    <span className="p-combobox__spinner" aria-hidden="true" />
+                    <span>{loadingMoreText}</span>
+                  </div>
+                ) : null}
+              </div>
+
+              {showLoadMore ? (
+                <div className="p-combobox__footer">
+                  <button type="button" className="p-combobox__load-more" onMouseDown={(event) => event.preventDefault()} onClick={requestLoadMore}>
+                    {loadMoreText}
+                  </button>
+                </div>
+              ) : null}
+            </div>
+          ) : null}
+        </div>
+
+        <input
+          ref={hiddenInputRef}
+          type="text"
+          name={name}
+          value={selectedValue ?? ''}
+          required={required}
+          tabIndex={-1}
+          aria-hidden="true"
+          className="p-combobox__hidden-input"
+          onChange={() => undefined}
+        />
+
+        {isOpen ? (
+          <div className="p-combobox__backdrop" aria-hidden="true" onMouseDown={closeCombobox} />
+        ) : null}
+
+        {isError && errorMessage ? (
+          <p id={errorId} role="alert" className="p-combobox__message p-combobox__message--error">
+            {errorMessage}
+          </p>
+        ) : null}
+
+        {!isError && helperText ? (
+          <p id={helperId} className="p-combobox__message">
+            {helperText}
+          </p>
+        ) : null}
+      </div>
+    );
+  },
+);
+
+PCombobox.displayName = 'PCombobox';

--- a/src/components/PCombobox/index.ts
+++ b/src/components/PCombobox/index.ts
@@ -1,0 +1,8 @@
+export {
+  PCombobox,
+  type PComboboxFilterMode,
+  type PComboboxOption,
+  type PComboboxProps,
+  type PComboboxQueryChangeSource,
+  type PComboboxRef,
+} from './PCombobox';

--- a/src/components/PDatePicker/PDatePicker.css
+++ b/src/components/PDatePicker/PDatePicker.css
@@ -1,14 +1,23 @@
 .p-date-picker {
-    --p-date-picker-bg: var(--p-color-surface);
-    --p-date-picker-bg-hover: var(--p-color-surface-subtle);
-    --p-date-picker-border: var(--p-color-border);
-    --p-date-picker-border-active: var(--p-color-border-strong);
-    --p-date-picker-text: var(--p-color-text);
-    --p-date-picker-text-muted: var(--p-color-text-muted);
+    --p-date-picker-bg: var(--p-control-bg);
+    --p-date-picker-bg-hover: var(--p-control-bg-hover);
+    --p-date-picker-bg-focus: var(--p-control-bg-focus);
+    --p-date-picker-border: var(--p-control-border);
+    --p-date-picker-border-active: var(--p-control-border-focus);
+    --p-date-picker-text: var(--p-control-text);
+    --p-date-picker-text-muted: var(--p-control-text-muted);
     --p-date-picker-accent: var(--p-color-action-primary);
     --p-date-picker-accent-subtle: var(--p-color-action-primary-subtle);
-    --p-date-picker-error: var(--p-color-danger);
-    --p-date-picker-radius: var(--p-radius-sm);
+    --p-date-picker-error: var(--p-control-border-error);
+    --p-date-picker-ring: var(--p-control-ring);
+    --p-date-picker-radius: var(--p-control-radius);
+    --p-date-picker-min-height: var(--p-size-control-lg);
+    --p-date-picker-padding-x: var(--p-control-padding-x);
+    --p-date-picker-padding-top: var(--p-space-6);
+    --p-date-picker-padding-bottom: var(--p-space-2);
+    --p-date-picker-label-top: var(--p-space-2);
+    --p-date-picker-placeholder-top: 50%;
+    --p-date-picker-message-margin-top: var(--p-control-message-margin-top);
     --p-date-picker-panel-width: 20rem;
     --p-date-picker-transition:
         background-color var(--p-duration-fast) var(--p-ease-standard),
@@ -63,19 +72,88 @@
 }
 
 .p-date-picker__trigger {
+    position: relative;
     display: flex;
     width: 100%;
-    min-height: var(--p-size-control-lg);
+    min-height: var(--p-date-picker-min-height);
     align-items: center;
     justify-content: space-between;
     gap: var(--p-space-3);
     border-radius: var(--p-date-picker-radius);
-    padding-inline: var(--p-space-4);
+    padding-block: var(--p-date-picker-padding-top) var(--p-date-picker-padding-bottom);
+    padding-inline: var(--p-date-picker-padding-x) var(--p-space-12);
     text-align: left;
 }
 
 .p-date-picker__trigger--empty {
+    color: var(--p-date-picker-text);
+}
+
+.p-date-picker__trigger-value {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.p-date-picker__trigger-label {
+    position: absolute;
+    inset-inline-start: var(--p-date-picker-padding-x);
+    max-width: calc(100% - var(--p-space-16));
+    overflow: hidden;
+    pointer-events: none;
+    text-overflow: ellipsis;
+    transform-origin: left;
+    white-space: nowrap;
+    transition:
+        opacity var(--p-duration-fast) var(--p-ease-standard),
+        color var(--p-duration-fast) var(--p-ease-standard),
+        transform var(--p-duration-fast) var(--p-ease-standard);
+}
+
+.p-date-picker__trigger-floating-label {
+    top: var(--p-date-picker-label-top);
     color: var(--p-date-picker-text-muted);
+    font-size: var(--p-control-message-font-size);
+    line-height: var(--p-control-message-line-height);
+    opacity: 0;
+    transform: scale(0);
+}
+
+.p-date-picker__trigger-placeholder-label {
+    top: var(--p-date-picker-placeholder-top);
+    color: var(--p-date-picker-text);
+    font-size: var(--p-control-font-size);
+    line-height: var(--p-control-line-height);
+    transform: translateY(-50%);
+}
+
+.p-date-picker__trigger--empty:not(.p-date-picker__trigger--open):not(:focus-visible)
+    .p-date-picker__trigger-value {
+    opacity: 0;
+}
+
+.p-date-picker__trigger--filled .p-date-picker__trigger-floating-label,
+.p-date-picker__trigger--open .p-date-picker__trigger-floating-label,
+.p-date-picker__trigger:focus-visible .p-date-picker__trigger-floating-label {
+    opacity: 1;
+    transform: scale(1);
+}
+
+.p-date-picker__trigger--open .p-date-picker__trigger-floating-label,
+.p-date-picker__trigger:focus-visible .p-date-picker__trigger-floating-label {
+    color: var(--p-date-picker-accent);
+}
+
+.p-date-picker__trigger--filled .p-date-picker__trigger-placeholder-label,
+.p-date-picker__trigger--open .p-date-picker__trigger-placeholder-label,
+.p-date-picker__trigger:focus-visible .p-date-picker__trigger-placeholder-label {
+    opacity: 0;
+    transform: translateY(-50%) scale(0);
+}
+
+.p-date-picker__trigger-label--error {
+    color: var(--p-date-picker-error);
 }
 
 .p-date-picker__trigger:hover,
@@ -91,7 +169,12 @@
 .p-date-picker__nav:focus-visible,
 .p-date-picker__day:focus-visible {
     outline: var(--p-focus-outline-width) solid transparent;
-    box-shadow: 0 0 0 var(--p-focus-ring-width) var(--p-focus-ring-color);
+    box-shadow: 0 0 0 var(--p-focus-ring-width) var(--p-date-picker-ring);
+}
+
+.p-date-picker__trigger:focus-visible {
+    background: var(--p-date-picker-bg-focus);
+    border-color: var(--p-date-picker-border-active);
 }
 
 .p-date-picker__trigger:disabled,
@@ -103,17 +186,24 @@
 }
 
 .p-date-picker__trigger-icon {
+    position: absolute;
+    top: 50%;
+    right: var(--p-date-picker-padding-x);
     display: inline-flex;
     width: var(--p-size-icon-md);
     height: var(--p-size-icon-md);
-    flex: 0 0 auto;
     color: var(--p-date-picker-text-muted);
+    transform: translateY(-50%);
 }
 
-.p-date-picker__trigger-icon svg,
-.p-date-picker__nav svg {
+.p-date-picker__trigger-icon svg {
     width: 100%;
     height: 100%;
+}
+
+.p-date-picker__nav svg {
+    width: var(--p-size-icon-sm);
+    height: var(--p-size-icon-sm);
 }
 
 .p-date-picker__presets {
@@ -160,18 +250,77 @@
 
 .p-date-picker__calendar-header {
     display: grid;
-    grid-template-columns: var(--p-size-control-md) 1fr var(--p-size-control-md);
+    grid-template-columns: var(--p-size-control-md) minmax(0, 1fr) var(--p-size-control-md);
     align-items: center;
-    gap: var(--p-space-2);
+    gap: 0;
+    overflow: hidden;
+    border: 1px solid var(--p-color-border-subtle);
+    border-radius: var(--p-date-picker-radius);
+    background: var(--p-color-surface-subtle);
     margin-block-end: var(--p-space-3);
 }
 
 .p-date-picker__month {
+    position: relative;
+    display: grid;
+    min-width: 0;
+    grid-template-columns: minmax(0, 1fr) 5rem;
+    align-items: center;
+    border-inline: 1px solid var(--p-color-border-subtle);
     color: var(--p-date-picker-text);
     font-size: var(--p-font-size-body-sm);
     font-weight: var(--p-font-weight-medium);
     line-height: var(--p-line-height-body-sm);
     text-align: center;
+}
+
+.p-date-picker__month-label {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+    clip: rect(0 0 0 0);
+    clip-path: inset(50%);
+    white-space: nowrap;
+}
+
+.p-date-picker__calendar-select {
+    min-width: 0;
+    height: var(--p-size-control-md);
+    border: 0;
+    border-radius: 0;
+    appearance: none;
+    background: transparent;
+    color: var(--p-date-picker-text);
+    cursor: pointer;
+    font: inherit;
+    font-size: var(--p-font-size-body-sm);
+    font-weight: var(--p-font-weight-medium);
+    line-height: var(--p-line-height-body-sm);
+    padding-inline: var(--p-space-3);
+    text-align: center;
+    text-overflow: ellipsis;
+    transition: var(--p-date-picker-transition);
+}
+
+.p-date-picker__month-select {
+    border-inline-end: 1px solid var(--p-color-border-subtle);
+}
+
+.p-date-picker__year-select {
+    color: var(--p-date-picker-text-muted);
+    font-variant-numeric: tabular-nums;
+}
+
+.p-date-picker__calendar-select:hover {
+    background: var(--p-date-picker-bg-hover);
+    color: var(--p-date-picker-text);
+}
+
+.p-date-picker__calendar-select:focus-visible {
+    outline: var(--p-focus-outline-width) solid transparent;
+    background: var(--p-date-picker-bg);
+    box-shadow: inset 0 0 0 var(--p-focus-ring-width) var(--p-date-picker-ring);
 }
 
 .p-date-picker__nav {
@@ -180,8 +329,19 @@
     height: var(--p-size-control-md);
     align-items: center;
     justify-content: center;
-    border-radius: var(--p-date-picker-radius);
+    border: 0;
+    border-radius: 0;
+    background: transparent;
     color: var(--p-date-picker-text-muted);
+}
+
+.p-date-picker__nav:hover {
+    background: var(--p-date-picker-bg-hover);
+    color: var(--p-date-picker-text);
+}
+
+.p-date-picker__nav:focus-visible {
+    box-shadow: inset 0 0 0 var(--p-focus-ring-width) var(--p-date-picker-ring);
 }
 
 .p-date-picker__weekdays,
@@ -224,7 +384,7 @@
 }
 
 .p-date-picker__message {
-    margin-block-start: var(--p-space-1);
+    margin-block-start: var(--p-date-picker-message-margin-top);
     color: var(--p-date-picker-text-muted);
     font-size: var(--p-font-size-caption);
     line-height: var(--p-line-height-caption);

--- a/src/components/PDatePicker/PDatePicker.tsx
+++ b/src/components/PDatePicker/PDatePicker.tsx
@@ -6,9 +6,11 @@ import {
   useRef,
   useState,
   type ButtonHTMLAttributes,
+  type ChangeEvent,
   type CSSProperties,
   type HTMLAttributes,
 } from 'react';
+import { CalendarIcon, ChevronLeftIcon, ChevronRightIcon } from '../../icons';
 import cn from '../../utils/cn';
 import './PDatePicker.css';
 
@@ -139,6 +141,13 @@ function getMonthLabel(date: Date, locale?: string) {
   return new Intl.DateTimeFormat(locale, { month: 'long', year: 'numeric' }).format(date);
 }
 
+function getMonthOptions(locale?: string) {
+  return Array.from({ length: 12 }, (_, month) => ({
+    label: new Intl.DateTimeFormat(locale, { month: 'long' }).format(new Date(2024, month, 1)),
+    value: month,
+  }));
+}
+
 function getDateLabel(date: Date, locale?: string) {
   return new Intl.DateTimeFormat(locale, {
     month: 'short',
@@ -175,31 +184,59 @@ function isAfterDate(date: Date, maxDate: Date | null) {
   return Boolean(maxDate && date.getTime() > maxDate.getTime());
 }
 
-function CalendarIcon() {
-  return (
-    <svg viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="1.75" aria-hidden="true">
-      <path d="M6 3v3" />
-      <path d="M14 3v3" />
-      <path d="M4 8h12" />
-      <path d="M5 5h10a1 1 0 0 1 1 1v10a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1V6a1 1 0 0 1 1-1Z" />
-    </svg>
-  );
+function isSameMonth(a: Date, b: Date) {
+  return a.getFullYear() === b.getFullYear() && a.getMonth() === b.getMonth();
 }
 
-function ChevronLeftIcon() {
-  return (
-    <svg viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="1.75" aria-hidden="true">
-      <path d="m12 5-5 5 5 5" />
-    </svg>
-  );
+function isMonthDisabled(monthDate: Date, minDate: Date | null, maxDate: Date | null) {
+  const monthStart = startOfMonth(monthDate);
+  const monthEnd = endOfMonth(monthDate);
+
+  return Boolean((minDate && monthEnd < minDate) || (maxDate && monthStart > maxDate));
 }
 
-function ChevronRightIcon() {
-  return (
-    <svg viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="1.75" aria-hidden="true">
-      <path d="m8 5 5 5-5 5" />
-    </svg>
+function clampVisibleMonth(monthDate: Date, minDate: Date | null, maxDate: Date | null) {
+  if (minDate && endOfMonth(monthDate) < minDate) {
+    return startOfMonth(minDate);
+  }
+
+  if (maxDate && startOfMonth(monthDate) > maxDate) {
+    return startOfMonth(maxDate);
+  }
+
+  return startOfMonth(monthDate);
+}
+
+function getFocusableDateInMonth(monthDate: Date, preferredDate: Date, minDate: Date | null, maxDate: Date | null) {
+  const monthStart = startOfMonth(monthDate);
+  const monthEnd = endOfMonth(monthDate);
+  let nextDate = new Date(
+    monthStart.getFullYear(),
+    monthStart.getMonth(),
+    Math.min(preferredDate.getDate(), monthEnd.getDate()),
   );
+
+  if (minDate && nextDate < minDate) {
+    nextDate = isSameMonth(minDate, monthStart) ? minDate : monthStart;
+  }
+
+  if (maxDate && nextDate > maxDate) {
+    nextDate = isSameMonth(maxDate, monthStart) ? maxDate : monthEnd;
+  }
+
+  return nextDate;
+}
+
+function getYearOptions(visibleMonth: Date, minDate: Date | null, maxDate: Date | null, today: Date) {
+  const visibleYear = visibleMonth.getFullYear();
+  const defaultStartYear = Math.min(visibleYear, today.getFullYear() - 100);
+  const defaultEndYear = Math.max(visibleYear, today.getFullYear() + 20);
+  const startYear = minDate?.getFullYear() ?? defaultStartYear;
+  const endYear = maxDate?.getFullYear() ?? defaultEndYear;
+  const firstYear = Math.min(startYear, endYear, visibleYear);
+  const lastYear = Math.max(startYear, endYear, visibleYear);
+
+  return Array.from({ length: lastYear - firstYear + 1 }, (_, index) => firstYear + index);
 }
 
 export const PDatePicker = forwardRef<PDatePickerRef, PDatePickerProps>(
@@ -250,8 +287,11 @@ export const PDatePicker = forwardRef<PDatePickerRef, PDatePickerProps>(
     const [focusedDate, setFocusedDate] = useState(() => selectedDate ?? today);
     const calendarTriggerRef = useRef<FocusableElement | null>(null);
     const dayRefs = useRef<Record<string, FocusableElement | null>>({});
+    const shouldFocusCalendarDateRef = useRef(false);
     const calendarDays = getCalendarDays(visibleMonth, weekStartsOn);
     const weekdayLabels = getWeekdayLabels(weekStartsOn, locale);
+    const monthOptions = useMemo(() => getMonthOptions(locale), [locale]);
+    const yearOptions = getYearOptions(visibleMonth, minDate, maxDate, today);
     const hasPresets = presets.length > 0;
     const shouldRenderCustom = hasPresets ? showCustom : true;
     const presetColumnsStyle =
@@ -266,13 +306,20 @@ export const PDatePicker = forwardRef<PDatePickerRef, PDatePickerProps>(
       ? presets.some((preset) => isSameDay(resolvePresetDate(preset), selectedDate))
       : false;
     const isCustomActive = isOpen || Boolean(selectedDate && !selectedMatchesPreset);
+    const previousMonth = addMonths(visibleMonth, -1);
+    const nextMonth = addMonths(visibleMonth, 1);
+    const isPreviousMonthDisabled = isMonthDisabled(previousMonth, minDate, maxDate);
+    const isNextMonthDisabled = isMonthDisabled(nextMonth, minDate, maxDate);
 
     useEffect(() => {
       if (!isOpen) {
         return;
       }
 
-      dayRefs.current[toIsoDate(focusedDate)]?.focus();
+      if (shouldFocusCalendarDateRef.current) {
+        dayRefs.current[toIsoDate(focusedDate)]?.focus();
+        shouldFocusCalendarDateRef.current = false;
+      }
     }, [focusedDate, isOpen, visibleMonth]);
 
     const setDateValue = (date: Date | null, source: PDatePickerChangeSource) => {
@@ -296,6 +343,7 @@ export const PDatePicker = forwardRef<PDatePickerRef, PDatePickerProps>(
 
       const nextFocusedDate = selectedDate ?? today;
       calendarTriggerRef.current = trigger as unknown as FocusableElement;
+      shouldFocusCalendarDateRef.current = true;
       setFocusedDate(nextFocusedDate);
       setVisibleMonth(startOfMonth(nextFocusedDate));
       setIsOpen(true);
@@ -307,6 +355,25 @@ export const PDatePicker = forwardRef<PDatePickerRef, PDatePickerProps>(
       if (restoreFocus) {
         calendarTriggerRef.current?.focus();
       }
+    };
+
+    const updateVisibleMonth = (nextMonth: Date) => {
+      const clampedMonth = clampVisibleMonth(nextMonth, minDate, maxDate);
+
+      setVisibleMonth(clampedMonth);
+      setFocusedDate(getFocusableDateInMonth(clampedMonth, focusedDate, minDate, maxDate));
+    };
+
+    const handleMonthChange = (event: ChangeEvent<HTMLSelectElement>) => {
+      const { value: nextMonth } = event.currentTarget as unknown as { value: string };
+
+      updateVisibleMonth(new Date(visibleMonth.getFullYear(), Number(nextMonth), 1));
+    };
+
+    const handleYearChange = (event: ChangeEvent<HTMLSelectElement>) => {
+      const { value: nextYear } = event.currentTarget as unknown as { value: string };
+
+      updateVisibleMonth(new Date(Number(nextYear), visibleMonth.getMonth(), 1));
     };
 
     const handlePresetClick = (preset: PDatePickerPreset) => {
@@ -334,6 +401,7 @@ export const PDatePicker = forwardRef<PDatePickerRef, PDatePickerProps>(
         return;
       }
 
+      shouldFocusCalendarDateRef.current = true;
       setFocusedDate(date);
       setVisibleMonth(startOfMonth(date));
     };
@@ -382,14 +450,14 @@ export const PDatePicker = forwardRef<PDatePickerRef, PDatePickerProps>(
           className,
         )}
       >
-        <div id={labelId} className="p-date-picker__label">
-          <span>{label}</span>
-          {hasPresets ? (
+        {hasPresets ? (
+          <div id={labelId} className="p-date-picker__label">
+            <span>{label}</span>
             <span className={cn('p-date-picker__label-value', !selectedDate && 'p-date-picker__label-value--empty')}>
               {displayValue}
             </span>
-          ) : null}
-        </div>
+          </div>
+        ) : null}
 
         {hasPresets ? (
           <div
@@ -438,16 +506,40 @@ export const PDatePicker = forwardRef<PDatePickerRef, PDatePickerProps>(
         ) : (
           <button
             type="button"
-            className={cn('p-date-picker__trigger', !selectedDate && 'p-date-picker__trigger--empty')}
+            className={cn(
+              'p-date-picker__trigger',
+              !selectedDate && 'p-date-picker__trigger--empty',
+              selectedDate && 'p-date-picker__trigger--filled',
+              isOpen && 'p-date-picker__trigger--open',
+            )}
             disabled={disabled}
             aria-controls={panelId}
             aria-describedby={messageId}
             aria-expanded={isOpen}
             aria-haspopup="dialog"
-            aria-labelledby={labelId}
+            aria-label={`${label}: ${displayValue}`}
             onClick={(event) => (isOpen ? closeCalendar(true) : openCalendar(event.currentTarget))}
           >
-            <span>{displayValue}</span>
+            <span
+              id={labelId}
+              className={cn(
+                'p-date-picker__trigger-label p-date-picker__trigger-floating-label',
+                isError && 'p-date-picker__trigger-label--error',
+              )}
+              aria-hidden="true"
+            >
+              {label}
+            </span>
+            <span
+              className={cn(
+                'p-date-picker__trigger-label p-date-picker__trigger-placeholder-label',
+                isError && 'p-date-picker__trigger-label--error',
+              )}
+              aria-hidden="true"
+            >
+              {label}
+            </span>
+            <span className="p-date-picker__trigger-value">{displayValue}</span>
             <span className="p-date-picker__trigger-icon">
               <CalendarIcon />
             </span>
@@ -473,18 +565,50 @@ export const PDatePicker = forwardRef<PDatePickerRef, PDatePickerProps>(
                 type="button"
                 className="p-date-picker__nav"
                 aria-label="Previous month"
-                onClick={() => setVisibleMonth((date) => addMonths(date, -1))}
+                disabled={isPreviousMonthDisabled}
+                onClick={() => updateVisibleMonth(previousMonth)}
               >
                 <ChevronLeftIcon />
               </button>
-              <div id={`${panelId}-title`} className="p-date-picker__month">
-                {getMonthLabel(visibleMonth, locale)}
+              <div className="p-date-picker__month">
+                <span id={`${panelId}-title`} className="p-date-picker__month-label">
+                  {getMonthLabel(visibleMonth, locale)}
+                </span>
+                <select
+                  className="p-date-picker__month-select p-date-picker__calendar-select"
+                  aria-label="Month"
+                  value={visibleMonth.getMonth()}
+                  onChange={handleMonthChange}
+                >
+                  {monthOptions.map((month) => (
+                    <option
+                      key={month.value}
+                      value={month.value}
+                      disabled={isMonthDisabled(new Date(visibleMonth.getFullYear(), month.value, 1), minDate, maxDate)}
+                    >
+                      {month.label}
+                    </option>
+                  ))}
+                </select>
+                <select
+                  className="p-date-picker__year-select p-date-picker__calendar-select"
+                  aria-label="Year"
+                  value={visibleMonth.getFullYear()}
+                  onChange={handleYearChange}
+                >
+                  {yearOptions.map((year) => (
+                    <option key={year} value={year}>
+                      {year}
+                    </option>
+                  ))}
+                </select>
               </div>
               <button
                 type="button"
                 className="p-date-picker__nav"
                 aria-label="Next month"
-                onClick={() => setVisibleMonth((date) => addMonths(date, 1))}
+                disabled={isNextMonthDisabled}
+                onClick={() => updateVisibleMonth(nextMonth)}
               >
                 <ChevronRightIcon />
               </button>

--- a/src/components/PDateRangePicker/PDateRangePicker.css
+++ b/src/components/PDateRangePicker/PDateRangePicker.css
@@ -1,14 +1,23 @@
 .p-date-range-picker {
-  --p-date-range-picker-bg: var(--p-color-surface);
-  --p-date-range-picker-bg-hover: var(--p-color-surface-subtle);
-  --p-date-range-picker-border: var(--p-color-border);
-  --p-date-range-picker-border-active: var(--p-color-border-strong);
-  --p-date-range-picker-text: var(--p-color-text);
-  --p-date-range-picker-text-muted: var(--p-color-text-muted);
+  --p-date-range-picker-bg: var(--p-control-bg);
+  --p-date-range-picker-bg-hover: var(--p-control-bg-hover);
+  --p-date-range-picker-bg-focus: var(--p-control-bg-focus);
+  --p-date-range-picker-border: var(--p-control-border);
+  --p-date-range-picker-border-active: var(--p-control-border-focus);
+  --p-date-range-picker-text: var(--p-control-text);
+  --p-date-range-picker-text-muted: var(--p-control-text-muted);
   --p-date-range-picker-accent: var(--p-color-action-primary);
   --p-date-range-picker-accent-subtle: var(--p-color-action-primary-subtle);
-  --p-date-range-picker-error: var(--p-color-danger);
-  --p-date-range-picker-radius: var(--p-radius-sm);
+  --p-date-range-picker-error: var(--p-control-border-error);
+  --p-date-range-picker-ring: var(--p-control-ring);
+  --p-date-range-picker-radius: var(--p-control-radius);
+  --p-date-range-picker-min-height: var(--p-size-control-lg);
+  --p-date-range-picker-padding-x: var(--p-control-padding-x);
+  --p-date-range-picker-padding-top: var(--p-space-6);
+  --p-date-range-picker-padding-bottom: var(--p-space-2);
+  --p-date-range-picker-label-top: var(--p-space-2);
+  --p-date-range-picker-placeholder-top: 50%;
+  --p-date-range-picker-message-margin-top: var(--p-control-message-margin-top);
   --p-date-range-picker-panel-width: 20rem;
   --p-date-range-picker-transition: background-color var(--p-duration-fast) var(--p-ease-standard),
     border-color var(--p-duration-fast) var(--p-ease-standard),
@@ -62,19 +71,87 @@
 }
 
 .p-date-range-picker__trigger {
+  position: relative;
   display: flex;
   width: 100%;
-  min-height: var(--p-size-control-lg);
+  min-height: var(--p-date-range-picker-min-height);
   align-items: center;
   justify-content: space-between;
   gap: var(--p-space-3);
   border-radius: var(--p-date-range-picker-radius);
-  padding-inline: var(--p-space-4);
+  padding-block: var(--p-date-range-picker-padding-top) var(--p-date-range-picker-padding-bottom);
+  padding-inline: var(--p-date-range-picker-padding-x) var(--p-space-12);
   text-align: left;
 }
 
 .p-date-range-picker__trigger--empty {
+  color: var(--p-date-range-picker-text);
+}
+
+.p-date-range-picker__trigger-value {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.p-date-range-picker__trigger-label {
+  position: absolute;
+  inset-inline-start: var(--p-date-range-picker-padding-x);
+  max-width: calc(100% - var(--p-space-16));
+  overflow: hidden;
+  pointer-events: none;
+  text-overflow: ellipsis;
+  transform-origin: left;
+  white-space: nowrap;
+  transition: opacity var(--p-duration-fast) var(--p-ease-standard),
+    color var(--p-duration-fast) var(--p-ease-standard),
+    transform var(--p-duration-fast) var(--p-ease-standard);
+}
+
+.p-date-range-picker__trigger-floating-label {
+  top: var(--p-date-range-picker-label-top);
   color: var(--p-date-range-picker-text-muted);
+  font-size: var(--p-control-message-font-size);
+  line-height: var(--p-control-message-line-height);
+  opacity: 0;
+  transform: scale(0);
+}
+
+.p-date-range-picker__trigger-placeholder-label {
+  top: var(--p-date-range-picker-placeholder-top);
+  color: var(--p-date-range-picker-text);
+  font-size: var(--p-control-font-size);
+  line-height: var(--p-control-line-height);
+  transform: translateY(-50%);
+}
+
+.p-date-range-picker__trigger--empty:not(.p-date-range-picker__trigger--open):not(:focus-visible)
+  .p-date-range-picker__trigger-value {
+  opacity: 0;
+}
+
+.p-date-range-picker__trigger--filled .p-date-range-picker__trigger-floating-label,
+.p-date-range-picker__trigger--open .p-date-range-picker__trigger-floating-label,
+.p-date-range-picker__trigger:focus-visible .p-date-range-picker__trigger-floating-label {
+  opacity: 1;
+  transform: scale(1);
+}
+
+.p-date-range-picker__trigger--open .p-date-range-picker__trigger-floating-label,
+.p-date-range-picker__trigger:focus-visible .p-date-range-picker__trigger-floating-label {
+  color: var(--p-date-range-picker-accent);
+}
+
+.p-date-range-picker__trigger--filled .p-date-range-picker__trigger-placeholder-label,
+.p-date-range-picker__trigger--open .p-date-range-picker__trigger-placeholder-label,
+.p-date-range-picker__trigger:focus-visible .p-date-range-picker__trigger-placeholder-label {
+  opacity: 0;
+  transform: translateY(-50%) scale(0);
+}
+
+.p-date-range-picker__trigger-label--error {
+  color: var(--p-date-range-picker-error);
 }
 
 .p-date-range-picker__trigger:hover,
@@ -90,7 +167,12 @@
 .p-date-range-picker__nav:focus-visible,
 .p-date-range-picker__day:focus-visible {
   outline: var(--p-focus-outline-width) solid transparent;
-  box-shadow: 0 0 0 var(--p-focus-ring-width) var(--p-focus-ring-color);
+  box-shadow: 0 0 0 var(--p-focus-ring-width) var(--p-date-range-picker-ring);
+}
+
+.p-date-range-picker__trigger:focus-visible {
+  background: var(--p-date-range-picker-bg-focus);
+  border-color: var(--p-date-range-picker-border-active);
 }
 
 .p-date-range-picker__trigger:disabled,
@@ -102,17 +184,24 @@
 }
 
 .p-date-range-picker__trigger-icon {
+  position: absolute;
+  top: 50%;
+  right: var(--p-date-range-picker-padding-x);
   display: inline-flex;
   width: var(--p-size-icon-md);
   height: var(--p-size-icon-md);
-  flex: 0 0 auto;
   color: var(--p-date-range-picker-text-muted);
+  transform: translateY(-50%);
 }
 
-.p-date-range-picker__trigger-icon svg,
-.p-date-range-picker__nav svg {
+.p-date-range-picker__trigger-icon svg {
   width: 100%;
   height: 100%;
+}
+
+.p-date-range-picker__nav svg {
+  width: var(--p-size-icon-sm);
+  height: var(--p-size-icon-sm);
 }
 
 .p-date-range-picker__presets {
@@ -159,18 +248,77 @@
 
 .p-date-range-picker__calendar-header {
   display: grid;
-  grid-template-columns: var(--p-size-control-md) 1fr var(--p-size-control-md);
+  grid-template-columns: var(--p-size-control-md) minmax(0, 1fr) var(--p-size-control-md);
   align-items: center;
-  gap: var(--p-space-2);
+  gap: 0;
+  overflow: hidden;
+  border: 1px solid var(--p-color-border-subtle);
+  border-radius: var(--p-date-range-picker-radius);
+  background: var(--p-color-surface-subtle);
   margin-block-end: var(--p-space-3);
 }
 
 .p-date-range-picker__month {
+  position: relative;
+  display: grid;
+  min-width: 0;
+  grid-template-columns: minmax(0, 1fr) 5rem;
+  align-items: center;
+  border-inline: 1px solid var(--p-color-border-subtle);
   color: var(--p-date-range-picker-text);
   font-size: var(--p-font-size-body-sm);
   font-weight: var(--p-font-weight-medium);
   line-height: var(--p-line-height-body-sm);
   text-align: center;
+}
+
+.p-date-range-picker__month-label {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  white-space: nowrap;
+}
+
+.p-date-range-picker__calendar-select {
+  min-width: 0;
+  height: var(--p-size-control-md);
+  border: 0;
+  border-radius: 0;
+  appearance: none;
+  background: transparent;
+  color: var(--p-date-range-picker-text);
+  cursor: pointer;
+  font: inherit;
+  font-size: var(--p-font-size-body-sm);
+  font-weight: var(--p-font-weight-medium);
+  line-height: var(--p-line-height-body-sm);
+  padding-inline: var(--p-space-3);
+  text-align: center;
+  text-overflow: ellipsis;
+  transition: var(--p-date-range-picker-transition);
+}
+
+.p-date-range-picker__month-select {
+  border-inline-end: 1px solid var(--p-color-border-subtle);
+}
+
+.p-date-range-picker__year-select {
+  color: var(--p-date-range-picker-text-muted);
+  font-variant-numeric: tabular-nums;
+}
+
+.p-date-range-picker__calendar-select:hover {
+  background: var(--p-date-range-picker-bg-hover);
+  color: var(--p-date-range-picker-text);
+}
+
+.p-date-range-picker__calendar-select:focus-visible {
+  outline: var(--p-focus-outline-width) solid transparent;
+  background: var(--p-date-range-picker-bg);
+  box-shadow: inset 0 0 0 var(--p-focus-ring-width) var(--p-date-range-picker-ring);
 }
 
 .p-date-range-picker__nav {
@@ -179,8 +327,19 @@
   height: var(--p-size-control-md);
   align-items: center;
   justify-content: center;
-  border-radius: var(--p-date-range-picker-radius);
+  border: 0;
+  border-radius: 0;
+  background: transparent;
   color: var(--p-date-range-picker-text-muted);
+}
+
+.p-date-range-picker__nav:hover {
+  background: var(--p-date-range-picker-bg-hover);
+  color: var(--p-date-range-picker-text);
+}
+
+.p-date-range-picker__nav:focus-visible {
+  box-shadow: inset 0 0 0 var(--p-focus-ring-width) var(--p-date-range-picker-ring);
 }
 
 .p-date-range-picker__weekdays,
@@ -228,7 +387,7 @@
 }
 
 .p-date-range-picker__message {
-  margin-block-start: var(--p-space-1);
+  margin-block-start: var(--p-date-range-picker-message-margin-top);
   color: var(--p-date-range-picker-text-muted);
   font-size: var(--p-font-size-caption);
   line-height: var(--p-line-height-caption);

--- a/src/components/PDateRangePicker/PDateRangePicker.tsx
+++ b/src/components/PDateRangePicker/PDateRangePicker.tsx
@@ -6,9 +6,11 @@ import {
   useRef,
   useState,
   type ButtonHTMLAttributes,
+  type ChangeEvent,
   type CSSProperties,
   type HTMLAttributes,
 } from 'react';
+import { CalendarIcon, ChevronLeftIcon, ChevronRightIcon } from '../../icons';
 import cn from '../../utils/cn';
 import './PDateRangePicker.css';
 
@@ -136,6 +138,13 @@ function getMonthLabel(date: Date, locale?: string) {
   return new Intl.DateTimeFormat(locale, { month: 'long', year: 'numeric' }).format(date);
 }
 
+function getMonthOptions(locale?: string) {
+  return Array.from({ length: 12 }, (_, month) => ({
+    label: new Intl.DateTimeFormat(locale, { month: 'long' }).format(new Date(2024, month, 1)),
+    value: month,
+  }));
+}
+
 function getDateLabel(date: Date, locale?: string) {
   return new Intl.DateTimeFormat(locale, {
     month: 'short',
@@ -174,6 +183,61 @@ function isBeforeDate(date: Date, minDate: Date | null) {
 
 function isAfterDate(date: Date, maxDate: Date | null) {
   return Boolean(maxDate && date.getTime() > maxDate.getTime());
+}
+
+function isSameMonth(a: Date, b: Date) {
+  return a.getFullYear() === b.getFullYear() && a.getMonth() === b.getMonth();
+}
+
+function isMonthDisabled(monthDate: Date, minDate: Date | null, maxDate: Date | null) {
+  const monthStart = startOfMonth(monthDate);
+  const monthEnd = endOfMonth(monthDate);
+
+  return Boolean((minDate && monthEnd < minDate) || (maxDate && monthStart > maxDate));
+}
+
+function clampVisibleMonth(monthDate: Date, minDate: Date | null, maxDate: Date | null) {
+  if (minDate && endOfMonth(monthDate) < minDate) {
+    return startOfMonth(minDate);
+  }
+
+  if (maxDate && startOfMonth(monthDate) > maxDate) {
+    return startOfMonth(maxDate);
+  }
+
+  return startOfMonth(monthDate);
+}
+
+function getFocusableDateInMonth(monthDate: Date, preferredDate: Date, minDate: Date | null, maxDate: Date | null) {
+  const monthStart = startOfMonth(monthDate);
+  const monthEnd = endOfMonth(monthDate);
+  let nextDate = new Date(
+    monthStart.getFullYear(),
+    monthStart.getMonth(),
+    Math.min(preferredDate.getDate(), monthEnd.getDate()),
+  );
+
+  if (minDate && nextDate < minDate) {
+    nextDate = isSameMonth(minDate, monthStart) ? minDate : monthStart;
+  }
+
+  if (maxDate && nextDate > maxDate) {
+    nextDate = isSameMonth(maxDate, monthStart) ? maxDate : monthEnd;
+  }
+
+  return nextDate;
+}
+
+function getYearOptions(visibleMonth: Date, minDate: Date | null, maxDate: Date | null, today: Date) {
+  const visibleYear = visibleMonth.getFullYear();
+  const defaultStartYear = Math.min(visibleYear, today.getFullYear() - 100);
+  const defaultEndYear = Math.max(visibleYear, today.getFullYear() + 20);
+  const startYear = minDate?.getFullYear() ?? defaultStartYear;
+  const endYear = maxDate?.getFullYear() ?? defaultEndYear;
+  const firstYear = Math.min(startYear, endYear, visibleYear);
+  const lastYear = Math.max(startYear, endYear, visibleYear);
+
+  return Array.from({ length: lastYear - firstYear + 1 }, (_, index) => firstYear + index);
 }
 
 function isInRange(date: Date, startDate: Date | null, endDate: Date | null) {
@@ -231,33 +295,6 @@ function getRangeLabel(value: PDateRangeValue | undefined, placeholder: string, 
   return placeholder;
 }
 
-function CalendarIcon() {
-  return (
-    <svg viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="1.75" aria-hidden="true">
-      <path d="M6 3v3" />
-      <path d="M14 3v3" />
-      <path d="M4 8h12" />
-      <path d="M5 5h10a1 1 0 0 1 1 1v10a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1V6a1 1 0 0 1 1-1Z" />
-    </svg>
-  );
-}
-
-function ChevronLeftIcon() {
-  return (
-    <svg viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="1.75" aria-hidden="true">
-      <path d="m12 5-5 5 5 5" />
-    </svg>
-  );
-}
-
-function ChevronRightIcon() {
-  return (
-    <svg viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="1.75" aria-hidden="true">
-      <path d="m8 5 5 5-5 5" />
-    </svg>
-  );
-}
-
 export const PDateRangePicker = forwardRef<PDateRangePickerRef, PDateRangePickerProps>(
   (
     {
@@ -307,8 +344,11 @@ export const PDateRangePicker = forwardRef<PDateRangePickerRef, PDateRangePicker
     const [focusedDate, setFocusedDate] = useState(() => startDate ?? today);
     const calendarTriggerRef = useRef<FocusableElement | null>(null);
     const dayRefs = useRef<Record<string, FocusableElement | null>>({});
+    const shouldFocusCalendarDateRef = useRef(false);
     const calendarDays = getCalendarDays(visibleMonth, weekStartsOn);
     const weekdayLabels = getWeekdayLabels(weekStartsOn, locale);
+    const monthOptions = useMemo(() => getMonthOptions(locale), [locale]);
+    const yearOptions = getYearOptions(visibleMonth, minDate, maxDate, today);
     const hasPresets = presets.length > 0;
     const shouldRenderCustom = hasPresets ? showCustom : true;
     const presetColumnsStyle =
@@ -324,13 +364,20 @@ export const PDateRangePicker = forwardRef<PDateRangePickerRef, PDateRangePicker
       ? presets.some((preset) => isSameRange(resolvePresetRange(preset), selectedValue))
       : false;
     const isCustomActive = isOpen || Boolean(hasCompleteRange && !selectedMatchesPreset);
+    const previousMonth = addMonths(visibleMonth, -1);
+    const nextMonth = addMonths(visibleMonth, 1);
+    const isPreviousMonthDisabled = isMonthDisabled(previousMonth, minDate, maxDate);
+    const isNextMonthDisabled = isMonthDisabled(nextMonth, minDate, maxDate);
 
     useEffect(() => {
       if (!isOpen) {
         return;
       }
 
-      dayRefs.current[toIsoDate(focusedDate)]?.focus();
+      if (shouldFocusCalendarDateRef.current) {
+        dayRefs.current[toIsoDate(focusedDate)]?.focus();
+        shouldFocusCalendarDateRef.current = false;
+      }
     }, [focusedDate, isOpen, visibleMonth]);
 
     const setRangeValue = (range: PDateRangeValue, source: PDateRangePickerChangeSource) => {
@@ -361,6 +408,7 @@ export const PDateRangePicker = forwardRef<PDateRangePickerRef, PDateRangePicker
 
       const nextFocusedDate = startDate ?? today;
       calendarTriggerRef.current = trigger as unknown as FocusableElement;
+      shouldFocusCalendarDateRef.current = true;
       setFocusedDate(nextFocusedDate);
       setVisibleMonth(startOfMonth(nextFocusedDate));
       setIsOpen(true);
@@ -372,6 +420,25 @@ export const PDateRangePicker = forwardRef<PDateRangePickerRef, PDateRangePicker
       if (restoreFocus) {
         calendarTriggerRef.current?.focus();
       }
+    };
+
+    const updateVisibleMonth = (nextMonth: Date) => {
+      const clampedMonth = clampVisibleMonth(nextMonth, minDate, maxDate);
+
+      setVisibleMonth(clampedMonth);
+      setFocusedDate(getFocusableDateInMonth(clampedMonth, focusedDate, minDate, maxDate));
+    };
+
+    const handleMonthChange = (event: ChangeEvent<HTMLSelectElement>) => {
+      const { value: nextMonth } = event.currentTarget as unknown as { value: string };
+
+      updateVisibleMonth(new Date(visibleMonth.getFullYear(), Number(nextMonth), 1));
+    };
+
+    const handleYearChange = (event: ChangeEvent<HTMLSelectElement>) => {
+      const { value: nextYear } = event.currentTarget as unknown as { value: string };
+
+      updateVisibleMonth(new Date(Number(nextYear), visibleMonth.getMonth(), 1));
     };
 
     const handlePresetClick = (preset: PDateRangePickerPreset) => {
@@ -404,6 +471,7 @@ export const PDateRangePicker = forwardRef<PDateRangePickerRef, PDateRangePicker
         return;
       }
 
+      shouldFocusCalendarDateRef.current = true;
       setFocusedDate(date);
       setVisibleMonth(startOfMonth(date));
     };
@@ -452,17 +520,19 @@ export const PDateRangePicker = forwardRef<PDateRangePickerRef, PDateRangePicker
           className,
         )}
       >
-        <div id={labelId} className="p-date-range-picker__label">
-          <span>{label}</span>
-          <span
-            className={cn(
-              'p-date-range-picker__label-value',
-              !hasCompleteRange && 'p-date-range-picker__label-value--empty',
-            )}
-          >
-            {displayValue}
-          </span>
-        </div>
+        {hasPresets ? (
+          <div id={labelId} className="p-date-range-picker__label">
+            <span>{label}</span>
+            <span
+              className={cn(
+                'p-date-range-picker__label-value',
+                !hasCompleteRange && 'p-date-range-picker__label-value--empty',
+              )}
+            >
+              {displayValue}
+            </span>
+          </div>
+        ) : null}
 
         {hasPresets ? (
           <div
@@ -514,16 +584,37 @@ export const PDateRangePicker = forwardRef<PDateRangePickerRef, PDateRangePicker
             className={cn(
               'p-date-range-picker__trigger',
               !hasCompleteRange && 'p-date-range-picker__trigger--empty',
+              hasCompleteRange && 'p-date-range-picker__trigger--filled',
+              isOpen && 'p-date-range-picker__trigger--open',
             )}
             disabled={disabled}
             aria-controls={panelId}
             aria-describedby={messageId}
             aria-expanded={isOpen}
             aria-haspopup="dialog"
-            aria-labelledby={labelId}
+            aria-label={`${label}: ${displayValue}`}
             onClick={(event) => (isOpen ? closeCalendar(true) : openCalendar(event.currentTarget))}
           >
-            <span>{displayValue}</span>
+            <span
+              id={labelId}
+              className={cn(
+                'p-date-range-picker__trigger-label p-date-range-picker__trigger-floating-label',
+                isError && 'p-date-range-picker__trigger-label--error',
+              )}
+              aria-hidden="true"
+            >
+              {label}
+            </span>
+            <span
+              className={cn(
+                'p-date-range-picker__trigger-label p-date-range-picker__trigger-placeholder-label',
+                isError && 'p-date-range-picker__trigger-label--error',
+              )}
+              aria-hidden="true"
+            >
+              {label}
+            </span>
+            <span className="p-date-range-picker__trigger-value">{displayValue}</span>
             <span className="p-date-range-picker__trigger-icon">
               <CalendarIcon />
             </span>
@@ -550,18 +641,50 @@ export const PDateRangePicker = forwardRef<PDateRangePickerRef, PDateRangePicker
                 type="button"
                 className="p-date-range-picker__nav"
                 aria-label="Previous month"
-                onClick={() => setVisibleMonth((date) => addMonths(date, -1))}
+                disabled={isPreviousMonthDisabled}
+                onClick={() => updateVisibleMonth(previousMonth)}
               >
                 <ChevronLeftIcon />
               </button>
-              <div id={`${panelId}-title`} className="p-date-range-picker__month">
-                {getMonthLabel(visibleMonth, locale)}
+              <div className="p-date-range-picker__month">
+                <span id={`${panelId}-title`} className="p-date-range-picker__month-label">
+                  {getMonthLabel(visibleMonth, locale)}
+                </span>
+                <select
+                  className="p-date-range-picker__month-select p-date-range-picker__calendar-select"
+                  aria-label="Month"
+                  value={visibleMonth.getMonth()}
+                  onChange={handleMonthChange}
+                >
+                  {monthOptions.map((month) => (
+                    <option
+                      key={month.value}
+                      value={month.value}
+                      disabled={isMonthDisabled(new Date(visibleMonth.getFullYear(), month.value, 1), minDate, maxDate)}
+                    >
+                      {month.label}
+                    </option>
+                  ))}
+                </select>
+                <select
+                  className="p-date-range-picker__year-select p-date-range-picker__calendar-select"
+                  aria-label="Year"
+                  value={visibleMonth.getFullYear()}
+                  onChange={handleYearChange}
+                >
+                  {yearOptions.map((year) => (
+                    <option key={year} value={year}>
+                      {year}
+                    </option>
+                  ))}
+                </select>
               </div>
               <button
                 type="button"
                 className="p-date-range-picker__nav"
                 aria-label="Next month"
-                onClick={() => setVisibleMonth((date) => addMonths(date, 1))}
+                disabled={isNextMonthDisabled}
+                onClick={() => updateVisibleMonth(nextMonth)}
               >
                 <ChevronRightIcon />
               </button>

--- a/src/components/PTextArea/PTextArea.css
+++ b/src/components/PTextArea/PTextArea.css
@@ -70,7 +70,6 @@
 
 .p-text-area__message {
   margin-block-start: var(--p-textarea-message-margin-top);
-  padding-inline: var(--p-textarea-padding-x);
   font-family: var(--p-font-family-sans);
   font-size: var(--p-textarea-message-font-size);
   line-height: var(--p-textarea-message-line-height);

--- a/src/components/PTextInput/PTextInput.css
+++ b/src/components/PTextInput/PTextInput.css
@@ -86,7 +86,6 @@
 
 .p-text-input__message {
   margin-block-start: var(--p-input-message-margin-top);
-  padding-inline: var(--p-input-padding-x);
   font-family: var(--p-font-family-sans);
   font-size: var(--p-input-message-font-size);
   line-height: var(--p-input-message-line-height);

--- a/src/components/PTypography/PTypography.stories.tsx
+++ b/src/components/PTypography/PTypography.stories.tsx
@@ -14,6 +14,13 @@ const meta: Meta<typeof PTypography> = {
       default: 'Dark',
     },
   },
+  decorators: [
+    (Story) => (
+      <div style={{ backgroundColor: P_COLORS.black }}>
+        <Story />
+      </div>
+    ),
+  ],
 };
 
 type Story = StoryObj<typeof PTypography>;

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -10,6 +10,14 @@ export {
 export { PButton, type PButtonProps, type PButtonRef } from './PButton';
 export { PCard, type PCardProps, type PCardRef } from './PCard';
 export {
+  PCombobox,
+  type PComboboxFilterMode,
+  type PComboboxOption,
+  type PComboboxProps,
+  type PComboboxQueryChangeSource,
+  type PComboboxRef,
+} from './PCombobox';
+export {
   PDatePicker,
   PDatePickerPresets,
   type PDatePickerChangeSource,

--- a/src/icons/Icons.mdx
+++ b/src/icons/Icons.mdx
@@ -1,4 +1,7 @@
 import {
+  CalendarIcon,
+  ChevronLeftIcon,
+  ChevronRightIcon,
   LinkedInIcon,
   MailIcon,
   NewTabArrowIcon,
@@ -22,6 +25,15 @@ import { P_COLORS } from '../constants';
 />
 
 <IconGallery>
+  <IconItem name='Calendar'>
+    <CalendarIcon className='text-black' />
+  </IconItem>
+  <IconItem name='Chevron Left'>
+    <ChevronLeftIcon className='text-black' />
+  </IconItem>
+  <IconItem name='Chevron Right'>
+    <ChevronRightIcon className='text-black' />
+  </IconItem>
   <IconItem name='Linkedin'>
     <LinkedInIcon className='text-black' />
   </IconItem>

--- a/src/icons/calendar-icon.tsx
+++ b/src/icons/calendar-icon.tsx
@@ -1,0 +1,23 @@
+import { SVGAttributes } from 'react';
+import { cn } from '../utils';
+
+type Props = SVGAttributes<SVGElement>;
+
+export default function CalendarIcon({ className, ...props }: Props) {
+  return (
+    <svg
+      viewBox="0 0 20 20"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.75"
+      aria-hidden="true"
+      className={cn(className)}
+      {...props}
+    >
+      <path d="M6 3v3" />
+      <path d="M14 3v3" />
+      <path d="M4 8h12" />
+      <path d="M5 5h10a1 1 0 0 1 1 1v10a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1V6a1 1 0 0 1 1-1Z" />
+    </svg>
+  );
+}

--- a/src/icons/chevron-left-icon.tsx
+++ b/src/icons/chevron-left-icon.tsx
@@ -1,0 +1,21 @@
+import { SVGAttributes } from 'react';
+import { cn } from '../utils';
+
+type Props = SVGAttributes<SVGElement>;
+
+export default function ChevronLeftIcon({ className, ...props }: Props) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth="1.5"
+      stroke="currentColor"
+      aria-hidden="true"
+      className={cn(className)}
+      {...props}
+    >
+      <path strokeLinecap="round" strokeLinejoin="round" d="M15.75 19.5 8.25 12l7.5-7.5" />
+    </svg>
+  );
+}

--- a/src/icons/chevron-right-icon.tsx
+++ b/src/icons/chevron-right-icon.tsx
@@ -1,0 +1,21 @@
+import { SVGAttributes } from 'react';
+import { cn } from '../utils';
+
+type Props = SVGAttributes<SVGElement>;
+
+export default function ChevronRightIcon({ className, ...props }: Props) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth="1.5"
+      stroke="currentColor"
+      aria-hidden="true"
+      className={cn(className)}
+      {...props}
+    >
+      <path strokeLinecap="round" strokeLinejoin="round" d="m8.25 4.5 7.5 7.5-7.5 7.5" />
+    </svg>
+  );
+}

--- a/src/icons/index.ts
+++ b/src/icons/index.ts
@@ -1,3 +1,6 @@
+export { default as CalendarIcon } from './calendar-icon';
+export { default as ChevronLeftIcon } from './chevron-left-icon';
+export { default as ChevronRightIcon } from './chevron-right-icon';
 export { default as TriangleListIcon } from './triangle-list-icon';
 export { default as LinkedInIcon } from './linkedin-icon';
 export { default as MailIcon } from './mail-icon';

--- a/src/theme.css
+++ b/src/theme.css
@@ -191,7 +191,7 @@
   --p-control-border-width: 1px;
   --p-control-padding-x: var(--p-space-4);
   --p-control-padding-y: var(--p-space-3);
-  --p-control-message-margin-top: var(--p-space-1);
+  --p-control-message-margin-top: calc(var(--p-space-1) / 2);
   --p-size-icon-sm: 1rem;
   --p-size-icon-md: 1.25rem;
   --p-size-icon-lg: 1.5rem;

--- a/tests/ui/storybook-smoke.spec.ts
+++ b/tests/ui/storybook-smoke.spec.ts
@@ -111,9 +111,100 @@ test.describe('Storybook smoke tests', () => {
     await expect(page.getByLabel('Label')).toBeDisabled();
   });
 
+  test('renders combobox search, selection, and mobile flow', async ({ page }) => {
+    await gotoStory(page, 'components-pcombobox--standard');
+
+    const combobox = page.getByRole('combobox', { name: 'Account owner' });
+    await expect(combobox).toBeVisible();
+    await expectElementWidthAtLeast(page, '.p-combobox', 350);
+
+    await combobox.click();
+    await expect(page.getByRole('listbox', { name: 'Account owner' })).toBeVisible();
+    const desktopPanelBox = await page.locator('.p-combobox__panel').boundingBox();
+    const desktopMessageBox = await page.locator('.p-combobox__message').boundingBox();
+    expect(desktopPanelBox?.y).toBeLessThan(desktopMessageBox?.y ?? 0);
+    await combobox.fill('security');
+    await expect(page.getByRole('option', { name: /Samuel Lee/ })).toBeVisible();
+    await page.getByRole('option', { name: /Samuel Lee/ }).click();
+    await expect(combobox).toHaveValue('Samuel Lee');
+
+    await combobox.click();
+    await page.keyboard.press('ArrowDown');
+    await page.keyboard.press('Enter');
+    await expect(combobox).not.toHaveValue('');
+
+    await page.setViewportSize({ width: 390, height: 844 });
+    await gotoStory(page, 'components-pcombobox--standard');
+    const mobileCombobox = page.getByRole('combobox', { name: 'Account owner', exact: true });
+    await mobileCombobox.click();
+    await expect(page.getByRole('listbox', { name: 'Account owner' })).toBeVisible();
+    await expect(mobileCombobox).not.toBeFocused();
+    await expect(page.getByRole('dialog', { name: 'Account owner' })).toBeVisible();
+    await expect(page.getByRole('combobox', { name: 'Search Account owner' })).toBeFocused();
+
+    const panelPosition = await page
+      .locator('.p-combobox__panel')
+      .evaluate((element) => getComputedStyle(element).position);
+    expect(panelPosition).toBe('fixed');
+    const mobilePanelBox = await page.locator('.p-combobox__panel').boundingBox();
+    const mobileInputBox = await mobileCombobox.boundingBox();
+    expect(mobilePanelBox?.height).toBeGreaterThanOrEqual(422);
+    expect(mobilePanelBox?.y ?? 0).toBeLessThan(mobileInputBox?.y ?? 0);
+    await expect(page.getByRole('button', { name: 'Close Account owner' })).toBeVisible();
+
+    await page.setViewportSize({ width: 768, height: 1024 });
+    await gotoStory(page, 'components-pcombobox--standard');
+    const tabletCombobox = page.getByRole('combobox', { name: 'Account owner', exact: true });
+    await tabletCombobox.click();
+    const tabletPanelPosition = await page
+      .locator('.p-combobox__panel')
+      .evaluate((element) => getComputedStyle(element).position);
+    expect(tabletPanelPosition).toBe('fixed');
+    const tabletPanelBox = await page.locator('.p-combobox__panel').boundingBox();
+    const tabletInputBox = await tabletCombobox.boundingBox();
+    expect(tabletPanelBox?.height).toBeGreaterThanOrEqual(510);
+    expect(tabletPanelBox?.y ?? 0).toBeLessThan(tabletInputBox?.y ?? 0);
+    await expect(tabletCombobox).not.toBeFocused();
+    await expect(page.getByRole('dialog', { name: 'Account owner' })).toBeVisible();
+    await expect(page.getByRole('combobox', { name: 'Search Account owner' })).toBeFocused();
+  });
+
+  test('renders combobox remote loading and pagination flow', async ({ page }) => {
+    await gotoStory(page, 'components-pcombobox--async-infinite-loading');
+
+    const combobox = page.getByRole('combobox', { name: 'Account API' });
+    await combobox.click();
+    await expect(page.getByRole('option', { name: /Loading accounts/ })).toBeVisible();
+    await expect(page.getByRole('option', { name: /Northstar 1/ })).toBeVisible();
+
+    await combobox.fill('account');
+    await expect(page.getByRole('option', { name: /Loading accounts/ })).toBeVisible();
+    await expect(page.getByRole('option', { name: /Security review/ }).first()).toBeVisible();
+
+    await page.getByRole('button', { name: 'Load next page' }).click();
+    await expect(page.getByText('Loading more accounts...')).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Load next page' })).toBeVisible();
+    await page.getByRole('button', { name: 'Load next page' }).click();
+    await expect(page.getByText('Loading more accounts...')).toBeVisible();
+  });
+
+  test('keeps combobox selection and form validity tied to committed values', async ({ page }) => {
+    await gotoStory(page, 'components-pcombobox--selected-option-mismatch');
+    await expect(page.getByRole('combobox', { name: 'Mismatched owner' })).toHaveValue('Nina Patel');
+
+    await gotoStory(page, 'components-pcombobox--required-form-field');
+    const invalidBeforeSelection = await page
+      .locator('input[name="approvalOwner"]')
+      .evaluate((element) => (element as HTMLInputElement).checkValidity());
+    expect(invalidBeforeSelection).toBe(false);
+  });
+
   test('renders date picker standard and preset flows', async ({ page }) => {
     await gotoStory(page, 'components-pdatepicker--standard');
     await expect(page.getByLabel('Due date')).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Due date: May 10, 2026' })).toBeVisible();
+    await expect(page.locator('.p-date-picker__label')).toHaveCount(0);
+    await expect(page.locator('.p-date-picker__trigger-floating-label')).toHaveText('Due date');
     await expectElementWidthAtLeast(page, '.p-date-picker', 350);
     await page.getByLabel('Due date').click();
     await expect(page.getByRole('dialog', { name: 'May 2026' })).toBeVisible();
@@ -122,6 +213,10 @@ test.describe('Storybook smoke tests', () => {
     await expect(selectedDueDate).toBeFocused();
     await page.keyboard.press('ArrowRight');
     await expect(page.getByRole('gridcell', { name: 'Monday, May 11, 2026' })).toBeFocused();
+    await page.getByRole('combobox', { name: 'Month' }).selectOption('6');
+    await expect(page.getByRole('dialog', { name: 'July 2026' })).toBeVisible();
+    await page.getByRole('combobox', { name: 'Year' }).selectOption('2027');
+    await expect(page.getByRole('dialog', { name: 'July 2027' })).toBeVisible();
 
     await gotoStory(page, 'components-pdatepicker--with-presets');
     await expect(page.getByRole('group', { name: 'Report date' })).toBeVisible();
@@ -142,6 +237,17 @@ test.describe('Storybook smoke tests', () => {
     const ownerAfter = await page.getByLabel('Owner').boundingBox();
     expect(ownerAfter?.y).toBeGreaterThan(ownerBefore?.y ?? 0);
 
+    await gotoStory(page, 'components-pdatepicker--with-bounds');
+    await page.getByLabel(/Booking date/).click();
+    await expect(page.getByRole('button', { name: 'Previous month' })).toBeDisabled();
+    await expect(page.getByRole('button', { name: 'Next month' })).toBeDisabled();
+    const disabledMonthOptions = await page
+      .getByRole('combobox', { name: 'Month' })
+      .evaluate((element) =>
+        Array.from((element as HTMLSelectElement).options).filter((option) => option.disabled).length,
+      );
+    expect(disabledMonthOptions).toBe(11);
+
     await gotoStory(page, 'components-pdatepicker--alternate-presets');
     await expect(page.getByRole('button', { name: 'Yesterday' })).toBeVisible();
     await expect(page.getByRole('button', { name: 'Tomorrow' })).toBeVisible();
@@ -154,6 +260,9 @@ test.describe('Storybook smoke tests', () => {
   test('renders date range picker selection and presets', async ({ page }) => {
     await gotoStory(page, 'components-pdaterangepicker--standard');
     await expect(page.getByRole('button', { name: /Report range/ })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Report range: May 1, 2026 - May 10, 2026' })).toBeVisible();
+    await expect(page.locator('.p-date-range-picker__label')).toHaveCount(0);
+    await expect(page.locator('.p-date-range-picker__trigger-floating-label')).toHaveText('Report range');
     await expectElementWidthAtLeast(page, '.p-date-range-picker', 350);
     await page.getByRole('button', { name: /Report range/ }).click();
     await expect(page.getByRole('dialog', { name: 'May 2026' })).toBeVisible();
@@ -166,12 +275,17 @@ test.describe('Storybook smoke tests', () => {
       'aria-selected',
       'true',
     );
+    await page.getByRole('combobox', { name: 'Month' }).selectOption('6');
+    await expect(page.getByRole('dialog', { name: 'July 2026' })).toBeVisible();
+    await page.getByRole('combobox', { name: 'Year' }).selectOption('2027');
+    await expect(page.getByRole('dialog', { name: 'July 2027' })).toBeVisible();
 
     await gotoStory(page, 'components-pdaterangepicker--empty');
     await page.getByRole('button', { name: /Booking range/ }).click();
     await page.getByRole('gridcell', { name: 'Monday, May 4, 2026' }).click();
     await page.getByRole('gridcell', { name: 'Friday, May 15, 2026' }).click();
-    await expect(page.locator('.p-date-range-picker__label-value')).toHaveText(
+    await expect(page.locator('.p-date-range-picker__label')).toHaveCount(0);
+    await expect(page.locator('.p-date-range-picker__trigger-value')).toHaveText(
       'May 4, 2026 - May 15, 2026',
     );
 
@@ -187,6 +301,17 @@ test.describe('Storybook smoke tests', () => {
     );
     await page.getByRole('button', { name: 'Custom' }).click();
     await expect(page.getByRole('dialog')).toBeVisible();
+
+    await gotoStory(page, 'components-pdaterangepicker--with-bounds');
+    await page.getByLabel(/Booking window/).click();
+    await expect(page.getByRole('button', { name: 'Previous month' })).toBeDisabled();
+    await expect(page.getByRole('button', { name: 'Next month' })).toBeDisabled();
+    const disabledRangeMonthOptions = await page
+      .getByRole('combobox', { name: 'Month' })
+      .evaluate((element) =>
+        Array.from((element as HTMLSelectElement).options).filter((option) => option.disabled).length,
+      );
+    expect(disabledRangeMonthOptions).toBe(11);
 
     await gotoStory(page, 'components-pdaterangepicker--presets-only');
     await expect(page.getByRole('button', { name: 'Year to date' })).toBeVisible();
@@ -312,6 +437,10 @@ test.describe('Storybook accessibility checks', () => {
     'components-phighlight--hero-use-case',
     'components-phighlight--custom-color',
     'components-phighlight--custom-background',
+    'components-pcombobox--standard',
+    'components-pcombobox--async-infinite-loading',
+    'components-pcombobox--required-form-field',
+    'components-pcombobox--with-error',
     'components-pdatepicker--standard',
     'components-pdatepicker--with-presets',
     'components-pdatepicker--many-presets',

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,52 +2,54 @@ import { defineConfig } from "vite";
 import dts from "vite-plugin-dts";
 import react from "@vitejs/plugin-react";
 import path from "path";
+import { cpSync, mkdirSync } from "node:fs";
 import tailwindcss from "@tailwindcss/vite";
-import { viteStaticCopy } from "vite-plugin-static-copy";
 
-const copyBinaryAsset = {
-  encoding: "buffer" as const,
-  handler: (content: Buffer) => content,
-};
+const staticAssetTargets = [
+  {
+    src: path.resolve(__dirname, "src/assets/fonts/AvantGarde"),
+    dest: path.resolve(__dirname, "dist/assets/fonts/AvantGarde"),
+  },
+  {
+    src: path.resolve(__dirname, "src/assets/fonts/ITC Avant Garde Gothic"),
+    dest: path.resolve(__dirname, "dist/assets/fonts/ITC Avant Garde Gothic"),
+  },
+  {
+    src: path.resolve(__dirname, "src/assets/fonts/Merriweather"),
+    dest: path.resolve(__dirname, "dist/assets/fonts/Merriweather"),
+  },
+  {
+    src: path.resolve(__dirname, "src/fonts.css"),
+    dest: path.resolve(__dirname, "dist/fonts.css"),
+  },
+  {
+    src: path.resolve(__dirname, "src/theme.css"),
+    dest: path.resolve(__dirname, "dist/theme.css"),
+  },
+  {
+    src: path.resolve(__dirname, "vite.config.ts"),
+    dest: path.resolve(__dirname, "dist/vite-config/vite.config.ts"),
+  },
+] as const;
+
+function copyStaticAssets() {
+  return {
+    name: "p-copy-static-assets",
+    apply: "build" as const,
+    closeBundle() {
+      for (const target of staticAssetTargets) {
+        mkdirSync(path.dirname(target.dest), { recursive: true });
+        cpSync(target.src, target.dest, { recursive: true, force: true });
+      }
+    },
+  };
+}
 
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [
     tailwindcss(),
-    viteStaticCopy({
-      targets: [
-        {
-          src: path.resolve(__dirname, "src/assets/fonts/AvantGarde/*.woff2"),
-          dest: "assets/fonts/AvantGarde",
-          transform: copyBinaryAsset,
-        },
-        {
-          src: path.resolve(
-            __dirname,
-            "src/assets/fonts/ITC Avant Garde Gothic/*.otf",
-          ),
-          dest: "assets/fonts/ITC Avant Garde Gothic",
-          transform: copyBinaryAsset,
-        },
-        {
-          src: path.resolve(__dirname, "src/assets/fonts/Merriweather/*.ttf"),
-          dest: "assets/fonts/Merriweather",
-          transform: copyBinaryAsset,
-        },
-        {
-          src: path.resolve(__dirname, "src/fonts.css"),
-          dest: ".",
-        },
-        {
-          src: path.resolve(__dirname, "src/theme.css"),
-          dest: ".",
-        },
-        {
-          src: "vite.config.ts",
-          dest: "vite-config",
-        },
-      ],
-    }),
+    copyStaticAssets(),
     react(),
     dts({ tsconfigPath: "./tsconfig.node.json", rollupTypes: true }),
   ],


### PR DESCRIPTION
Adds the enterprise PCombobox, refines PDatePicker and PDateRangePicker field/menu behavior, normalizes helper text spacing, registers shared calendar/chevron icons, and expands Storybook smoke/a11y coverage. Verified with npm run lint, npm run build, npm run build:storybook, and npx playwright test.